### PR TITLE
Add a new createHttpClient() method to NetworkUtilities

### DIFF
--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/MainActivity.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/MainActivity.java
@@ -1119,12 +1119,7 @@ public class MainActivity extends ActionBarActivity implements OnGlobalLayoutLis
 	        post.setHeader("Accept-Charset","utf-8");
 
 
-	        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-            final HttpParams httpParams = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(httpParams,
-            		NetworkUtilities.REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+	        DefaultHttpClient mHttpClient = NetworkUtilities.createHttpClient();
 	        
 	        try {
 	            resp = mHttpClient.execute(post);

--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/NetworkUtilities.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/NetworkUtilities.java
@@ -78,13 +78,21 @@ public class NetworkUtilities {
      */
     public static void maybeCreateHttpClient() {
         if (mHttpClient == null) {
-            mHttpClient = new DefaultHttpClient();
-            final HttpParams params = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(params,
-                REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(params, REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(params, REGISTRATION_TIMEOUT);
+            mHttpClient = createHttpClient();
         }
+    }
+
+    /**
+     * Constructs a new DefaultHttpClient with a default 30 second timeout.
+     */
+    public static DefaultHttpClient createHttpClient() {
+        DefaultHttpClient client = new DefaultHttpClient();
+        final HttpParams params = client.getParams();
+        HttpConnectionParams.setConnectionTimeout(params,
+            REGISTRATION_TIMEOUT);
+        HttpConnectionParams.setSoTimeout(params, REGISTRATION_TIMEOUT);
+        ConnManagerParams.setTimeout(params, REGISTRATION_TIMEOUT);
+        return client;
     }
 
     /**

--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/fragments/DataFragment.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/fragments/DataFragment.java
@@ -507,12 +507,7 @@ public class DataFragment extends Fragment implements OnClickListener {
 		        post.setHeader("Accept-Charset","utf-8");
 
 
-		        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-	            final HttpParams httpParams = mHttpClient.getParams();
-	            HttpConnectionParams.setConnectionTimeout(httpParams,
-	            		NetworkUtilities.REGISTRATION_TIMEOUT);
-	            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-	            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+		        DefaultHttpClient mHttpClient = NetworkUtilities.createHttpClient();
 		        
 		        try {
 		            resp = mHttpClient.execute(post);
@@ -696,12 +691,7 @@ public class DataFragment extends Fragment implements OnClickListener {
 	        post.setHeader("Accept-Charset","utf-8");
 
 
-	        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-            final HttpParams httpParams = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(httpParams,
-            		NetworkUtilities.REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+	        DefaultHttpClient mHttpClient = NetworkUtilities.createHttpClient();
 	        
 	        try {
 	            resp = mHttpClient.execute(post);
@@ -844,12 +834,7 @@ public class DataFragment extends Fragment implements OnClickListener {
 	        post.setHeader("Accept-Charset","utf-8");
 
 
-	        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-            final HttpParams httpParams = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(httpParams,
-            		NetworkUtilities.REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+	        DefaultHttpClient mHttpClient = NetworkUtilities.createHttpClient();
 	        
 	        try {
 	            resp = mHttpClient.execute(post);
@@ -933,12 +918,7 @@ public class DataFragment extends Fragment implements OnClickListener {
 	        Log.e("GET", NetworkUtilities.TREE_SYNC_URI + treeId + "?token=" + mSharedPreferences.getString(ValueHelper.TOKEN, ""));
 
 
-	        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-            final HttpParams httpParams = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(httpParams,
-            		NetworkUtilities.REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+	        DefaultHttpClient mHttpClient = NetworkUtilties.createHttpClient();
 	        
 	        try {
 	            resp = mHttpClient.execute(post);
@@ -1222,12 +1202,7 @@ public class DataFragment extends Fragment implements OnClickListener {
 	        post.setHeader("Accept-Charset","utf-8");
 
 
-	        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-            final HttpParams httpParams = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(httpParams,
-            		NetworkUtilities.REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+	        DefaultHttpClient mHttpClient = NetworkUtilities.createHttpClient();
 	        
 	        try {
 	            resp = mHttpClient.execute(post);

--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/fragments/ForgotPasswordFragment.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/fragments/ForgotPasswordFragment.java
@@ -174,12 +174,7 @@ public class ForgotPasswordFragment extends Fragment implements OnClickListener 
 	        post.setHeader("Accept-Charset","utf-8");
 
 
-	        DefaultHttpClient mHttpClient = new DefaultHttpClient();
-            final HttpParams httpParams = mHttpClient.getParams();
-            HttpConnectionParams.setConnectionTimeout(httpParams,
-            		NetworkUtilities.REGISTRATION_TIMEOUT);
-            HttpConnectionParams.setSoTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
-            ConnManagerParams.setTimeout(httpParams, NetworkUtilities.REGISTRATION_TIMEOUT);
+	        DefaultHttpClient mHttpClient = NetworkUtilities.createHttpClient();
 	        
 	        try {
 	            resp = mHttpClient.execute(post);


### PR DESCRIPTION
createHttpClient() constructs a DefaultHttpClient with no URL and a 30
second timeout.  All instantiations of DefaultHttpClient with this
timeout are also updated to use the new method.

This commit should not change any existing behavior; the only purpose is
to reduce duplicated code.