### PR TITLE
Change to dospaces cloud storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,8 @@ android {
         versionName "1.0.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        buildConfigField "String", "DOS_ACCESS_KEY", "\"${dos_access_key}\""
+        buildConfigField "String", "DOS_SECRET_KEY", "\"${dos_secret_key}\""
     }
     buildTypes {
         release {
@@ -23,19 +25,16 @@ android {
         }
         debug {
             applicationIdSuffix ".debug"
-            minifyEnabled true
             resValue "string", "app_name", "Tree Tracker(debug)"
             buildConfigField "String", "GPS_ACCURACY", '"off"'
             buildConfigField 'String', 'BASE_URL', '"http://dev.treetracker.org"'
             buildConfigField "String", "DB_PATH", '"/data/data/com.qalliance.treetracker.TreeTracker.debug/databases/"'
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         dev {
             initWith(debug)
             applicationIdSuffix ".dev"
             resValue "string", "app_name", "Tree Tracker(dev)"
             buildConfigField "String", "DB_PATH", '"/data/data/com.qalliance.treetracker.TreeTracker.dev/databases/"'
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         qa {
             initWith(debug)
@@ -44,7 +43,6 @@ android {
             buildConfigField "String", "GPS_ACCURACY", '"on"'
             buildConfigField 'String', 'BASE_URL', '"http://test.treetracker.org"'
             buildConfigField "String", "DB_PATH", '"/data/data/com.qalliance.treetracker.TreeTracker.qa/databases/"'
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
     productFlavors {
@@ -72,4 +70,6 @@ dependencies {
     compile "com.squareup.retrofit2:retrofit:${retrofit2Version}"
     compile "com.squareup.retrofit2:converter-gson:${retrofit2Version}"
     compile 'com.jakewharton.timber:timber:4.6.0'
+    compile 'com.amazonaws:aws-android-sdk-core:2.2.+'
+    compile 'com.amazonaws:aws-android-sdk-s3:2.2.+'
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,3 +34,17 @@
     public private *;
 }
 -keep public class com.google.android.gms.*
+
+# Class names are needed in reflection
+-keepnames class com.amazonaws.**
+-keepnames class com.amazon.**
+# Request handlers defined in request.handlers
+-keep class com.amazonaws.services.**.*Handler
+# The following are referenced but aren't required to run
+-dontwarn com.fasterxml.jackson.**
+-dontwarn org.apache.commons.logging.**
+# Android 6.0 release removes support for the Apache HTTP client
+-dontwarn org.apache.http.**
+# The SDK has several references of Apache HTTP client
+-dontwarn com.amazonaws.http.**
+-dontwarn com.amazonaws.metrics.**

--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/api/DOSpaces.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/api/DOSpaces.java
@@ -20,7 +20,7 @@ import java.io.File;
 public class DOSpaces {
 
     public static final String ENDPOINT = "https://nyc3.digitaloceanspaces.com";
-    public static final String BUCKET = "my-bucket";
+    public static final String BUCKET = "treetracker-dev";
 
 
     private static DOSpaces sInstance;

--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/api/DOSpaces.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/api/DOSpaces.java
@@ -1,0 +1,57 @@
+package com.qalliance.treetracker.TreeTracker.api;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.GroupGrantee;
+import com.amazonaws.services.s3.model.Permission;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.qalliance.treetracker.TreeTracker.BuildConfig;
+
+import java.io.File;
+
+/**
+ * Created by lei on 12/11/17.
+ */
+
+public class DOSpaces {
+
+    public static final String ENDPOINT = "https://nyc3.digitaloceanspaces.com";
+    public static final String BUCKET = "my-bucket";
+
+
+    private static DOSpaces sInstance;
+    private AmazonS3 s3Client;
+
+    public static DOSpaces instance() {
+        if (sInstance == null) {
+            sInstance = new DOSpaces();
+        }
+        return sInstance;
+    }
+
+    private DOSpaces() {
+        BasicAWSCredentials basicAWSCredentials =
+                new BasicAWSCredentials(BuildConfig.DOS_ACCESS_KEY, BuildConfig.DOS_SECRET_KEY);
+        s3Client = new AmazonS3Client(basicAWSCredentials);
+        s3Client.setEndpoint(ENDPOINT);
+    }
+
+    public String put(String path, int userId) throws AmazonClientException {
+        AccessControlList acl = new AccessControlList();
+        acl.grantPermission(GroupGrantee.AllUsers, Permission.Read);
+
+        File image = new File(path);
+        String dosKey = Integer.toString(userId) + '/' + image.getName();
+        PutObjectRequest poRequest =
+                new PutObjectRequest(BUCKET, dosKey, image);
+        poRequest.withAccessControlList(acl);
+        PutObjectResult poResult = s3Client.putObject(poRequest);
+        String imageUrl = String.format("https://%s.nyc3.digitaloceanspaces.com/%s", BUCKET, dosKey);
+        return imageUrl;
+    }
+
+}

--- a/app/src/main/java/com/qalliance/treetracker/TreeTracker/api/SyncTask.java
+++ b/app/src/main/java/com/qalliance/treetracker/TreeTracker/api/SyncTask.java
@@ -8,12 +8,14 @@ import android.database.DatabaseUtils;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
+import android.util.Log;
 
-import com.qalliance.treetracker.TreeTracker.utilities.Utils;
+import com.amazonaws.AmazonClientException;
 import com.qalliance.treetracker.TreeTracker.activities.MainActivity;
 import com.qalliance.treetracker.TreeTracker.api.models.NewTree;
 import com.qalliance.treetracker.TreeTracker.api.models.PostResult;
 import com.qalliance.treetracker.TreeTracker.database.DatabaseManager;
+import com.qalliance.treetracker.TreeTracker.utilities.Utils;
 
 import java.io.File;
 
@@ -93,8 +95,32 @@ public class SyncTask extends AsyncTask<Void, Void, String> {
             String timeCreated = treeCursor.getString(treeCursor.getColumnIndex("tree_time_created"));
             newTree.setTimestamp(Utils.convertDateToTimestamp(timeCreated));
 
+            /**
+             * Implementation for saving image into DigitalOcean Spaces.
+             */
+            String imagePath = treeCursor.getString(treeCursor.getColumnIndex("name"));
+            String imageUrl;
+            try {
+                imageUrl = DOSpaces.instance().put(imagePath, userId);
+            } catch (AmazonClientException ace) {
+                Log.e("SyncTask", "Caught an AmazonClientException, which " +
+                        "means the client encountered " +
+                        "an internal error while trying to " +
+                        "communicate with S3, " +
+                        "such as not being able to access the network.");
+                Log.e("SyncTask", "Error Message: " + ace.getMessage());
+                return "Failed.";
+            }
+            Log.d("SyncTask", "imageUrl: " + imageUrl);
+            //newTree.setBase64Image(imageUrl); // method name should be changed as use new infrastructure.
+
+            /**
+             * Current version of saving image in base 64 format to server, will be deprecated
+             * after use DigitalOcean cloud storage.
+             */
             String image = Utils.base64Image(treeCursor.getString(treeCursor.getColumnIndex("name")));
             newTree.setBase64Image(image);
+
 //            Timber.tag("DataFragment").d("user_id: " + newTree.getUserId());
 //            Timber.tag("DataFragment").d("lat: " + newTree.getLat());
 //            Timber.tag("DataFragment").d("lon: " + newTree.getLon());

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+dos_access_key=<update_to_digitalocean_access_key>
+dos_secret_key=<update_to_digitalocean_secret_key>


### PR DESCRIPTION
Upload tree images to Digital Ocean Spaces storage. Return the image url to the server rather than base 64 image format. This function will compatible with the new server infrastructure, so keep code in this branch until new server API release. Access key and secret key should be changed in the gradle.properties file and keep it local.