### PR TITLE
Initial Gradle plugin for Appstore Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ This project coordinates tree planting employment for people living in extreme p
 The Android segment allows people to track and verify reforestation plantings,
 paying planters on a per planting basis.
 
+## Deployment
+
+There is one prerequisite to using the appropriate gradle tasks:
+
+1) Placing the relevant keys.json from the PlayStore in the ./app folder [example here](https://docs.fastlane.tools/getting-started/android/setup/#collect-your-google-credentials)
+
+Once this is done, you can then proceed by running one of the following tasks to run the release:
+
+* `bootstrapReleasePlayResources` | Downloads the play store listing for the Release build. No download of image resources. See #18.
+* `generateReleasePlayResources`  | Collects play store resources for the Release build
+* `publishListingRelease`         | Updates the play store listing for the Release build
+
 ## Contributing
 
 Please review the roadmap (https://github.com/Greenstand/treetracker.org/wiki/Roadmap) or issue tracker here on github.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,26 @@
 buildscript {
     repositories {
         maven { url 'https://maven.fabric.io/public' }
+        jcenter()
     }
 
     dependencies {
         classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'com.github.triplet.gradle:play-publisher:1.2.0'
     }
 }
 apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
-
+apply plugin: 'com.github.triplet.play'
 
 android {
     compileSdkVersion 25
     buildToolsVersion "26.0.2"
+    playAccountConfigs {
+        defaultAccountConfig {
+            jsonFile = file('keys.json')
+        }
+    }
     defaultConfig {
         applicationId "org.greenstand.android.TreeTracker"
         minSdkVersion 15
@@ -22,6 +29,7 @@ android {
         versionName "1.1.4"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        playAccountConfig = playAccountConfigs.defaultAccountConfig
     }
     buildTypes {
         release {
@@ -95,5 +103,8 @@ dependencies {
     }
     compile 'com.google.firebase:firebase-core:11.8.0'
 
+}
+play {
+    track = 'beta' // or 'rollout' or 'production' or 'alpha'
 }
 //apply plugin: 'com.google.gms.google-services'


### PR DESCRIPTION
Part of Issue #42 
Still requires hooking into some sort of CD mechanism, but at least allows doing something from the command line.