### PR TITLE
Document Android Fabric Deployment Steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+app/fabric.properties
 
 # Windows thumbnail db
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Once this is done, you can then proceed by running one of the following tasks to
 * `generateReleasePlayResources`  | Collects play store resources for the Release build
 * `publishListingRelease`         | Updates the play store listing for the Release build
 
+## Deploying to Fabric
+
+To deploy to the fabric build, there are two things that need to be done:
+
+1. Inside of /app, place a `fabric.properties` file, that contains the following
+```
+apiKey=<API_KEY_HERE>
+apiSecret=<API_SECRET_HERE>
+```
+1. Run `./gradlew assembleDebug crashlyticsUploadDistributionDebug`
+
 ## Contributing
 
  (https://github.com/Greenstand/Development-Overview/blob/master/Contributing.md) 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -97,9 +97,6 @@
             android:value="AIzaSyD-kTHgZzm7Cx18yyqQjMeQV3an3cuyqnc"/>
             -->
 
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="a1a27770fb1f13f8ce4a3939116272205df62792" />
         <provider
             android:name="android.support.v4.content.FileProvider"
             android:authorities="${applicationId}.provider"


### PR DESCRIPTION
* Remove unnecessary API Key
* Add to readme explanation of how to create
properties file and which command to run to push
the fabric build