### PR TITLE
Idiomatic kotlin refactor

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/Api.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/Api.kt
@@ -13,7 +13,6 @@ import timber.log.Timber
 
 class Api {
     private var apiService: ApiService? = null
-    private var mOkHttpClient: OkHttpClient? = null
     private var authToken: String? = null
 
     val api: ApiService?
@@ -32,13 +31,13 @@ class Api {
     }
 
     private fun createApi() {
-        mOkHttpClient = OkHttpClient.Builder()
+        val client = OkHttpClient.Builder()
                 .addInterceptor(loggingInterceptor())
                 .addInterceptor(AuthenticationInterceptor())
                 .build()
 
         apiService = Retrofit.Builder()
-                .client(mOkHttpClient!!)
+                .client(client)
                 .baseUrl(ApiService.ENDPOINT)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
@@ -54,9 +53,9 @@ class Api {
             val original = chain.request()
 
             if (authToken != null) {
-                val builder = original.newBuilder()
-                        .header("Authorization", "Bearer " + authToken!!)
-                val request = builder.build()
+                val request = original.newBuilder()
+                    .header("Authorization", "Bearer $authToken")
+                    .build()
                 return chain.proceed(request)
             } else {
                 return chain.proceed(original)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/AuthenticationRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/AuthenticationRequest.kt
@@ -1,19 +1,15 @@
 package org.greenstand.android.TreeTracker.api.models.requests
 
 import com.google.gson.annotations.SerializedName
+import org.greenstand.android.TreeTracker.BuildConfig
 
 /**
  * Created by zaven on 4/8/18.
  */
 
-class AuthenticationRequest {
-
-    @SerializedName("client_id")
-    var clientId: String? = null
-
-    @SerializedName("client_secret")
-    var clientSecret: String? = null
-
-    @SerializedName("device_android_id")
-    var deviceAndroidId: String? = null
-}
+data class AuthenticationRequest(@SerializedName("client_id")
+                                 val clientId: String = BuildConfig.TREETRACKER_CLIENT_ID,
+                                 @SerializedName("client_secret")
+                                 val clientSecret: String = BuildConfig.TREETRACKER_CLIENT_SECRET,
+                                 @SerializedName("device_android_id")
+                                 val deviceAndroidId: String)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/DeviceRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/DeviceRequest.kt
@@ -1,37 +1,26 @@
 package org.greenstand.android.TreeTracker.api.models.requests
 
+import android.os.Build
 import com.google.gson.annotations.SerializedName
+import org.greenstand.android.TreeTracker.BuildConfig
 
-class DeviceRequest {
-
-    @SerializedName("app_version")
-    var app_version: String? = null
-
-    @SerializedName("app_build")
-    var app_build: Int? = null
-
-    @SerializedName("manufacturer")
-    var manufacturer: String? = null
-
-    @SerializedName("brand")
-    var brand: String? = null
-
-    @SerializedName("model")
-    var model: String? = null
-
-    @SerializedName("hardware")
-    var hardware: String? = null
-
-    @SerializedName("device")
-    var device: String? = null
-
-    @SerializedName("serial")
-    var serial: String? = null
-
-    @SerializedName("androidRelease")
-    var androidRelease: String? = null
-
-    @SerializedName("androidSdkVersion")
-    var androidSdkVersion: Int? = null
-
-}
+data class DeviceRequest(@SerializedName("app_version")
+                         val app_version: String = BuildConfig.VERSION_NAME,
+                         @SerializedName("app_build")
+                         val app_build: Int = BuildConfig.VERSION_CODE,
+                         @SerializedName("manufacturer")
+                         val manufacturer: String = Build.MANUFACTURER,
+                         @SerializedName("brand")
+                         val brand: String = Build.BRAND,
+                         @SerializedName("model")
+                         val model: String = Build.MODEL,
+                         @SerializedName("hardware")
+                         val hardware: String = Build.HARDWARE,
+                         @SerializedName("device")
+                         val device: String = Build.DEVICE,
+                         @SerializedName("serial")
+                         val serial: String = Build.SERIAL,
+                         @SerializedName("androidRelease")
+                         val androidRelease: String = Build.VERSION.RELEASE,
+                         @SerializedName("androidSdkVersion")
+                         val androidSdkVersion: Int = Build.VERSION.SDK_INT)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/NewTreeRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/NewTreeRequest.kt
@@ -2,33 +2,25 @@ package org.greenstand.android.TreeTracker.api.models.requests
 
 import com.google.gson.annotations.SerializedName
 
-class NewTreeRequest {
+class NewTreeRequest(
     @SerializedName("user_id")
-    var userId: Int = 0
+    val userId: Int = 0,
     @SerializedName("lat")
-    var lat: Double = 0.toDouble()
+    val lat: Double = 0.toDouble(),
     @SerializedName("lon")
-    var lon: Double = 0.toDouble()
+    val lon: Double = 0.toDouble(),
     @SerializedName("gps_accuracy")
-    private var gpsAccuracy: Int = 0
+    val gpsAccuracy: Int = 0,
     @SerializedName("note")
-    var note: String? = null
+    val note: String? = null,
     @SerializedName("timestamp")
-    var timestamp: Long = 0
+    val timestamp: Long = 0,
     @SerializedName("image_url")
-    var imageUrl: String? = null
+    val imageUrl: String? = null,
     @SerializedName("sequence_id")
-    var sequenceId: Long = 0
+    val sequenceId: Long = 0,
     @SerializedName("planter_photo_url")
-    var planterPhotoUrl: String? = null
+    val planterPhotoUrl: String? = null,
     @SerializedName("planter_identifier")
-    var planterIdentifier: String? = null
-
-    fun getGpsAccuracy(): Float {
-        return gpsAccuracy.toFloat()
-    }
-
-    fun setGpsAccuracy(gpsAccuracy: Int) {
-        this.gpsAccuracy = gpsAccuracy
-    }
-}
+    val planterIdentifier: String? = null
+)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/NewTreeRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/NewTreeRequest.kt
@@ -2,25 +2,23 @@ package org.greenstand.android.TreeTracker.api.models.requests
 
 import com.google.gson.annotations.SerializedName
 
-class NewTreeRequest(
-    @SerializedName("user_id")
-    val userId: Int = 0,
-    @SerializedName("lat")
-    val lat: Double = 0.toDouble(),
-    @SerializedName("lon")
-    val lon: Double = 0.toDouble(),
-    @SerializedName("gps_accuracy")
-    val gpsAccuracy: Int = 0,
-    @SerializedName("note")
-    val note: String? = null,
-    @SerializedName("timestamp")
-    val timestamp: Long = 0,
-    @SerializedName("image_url")
-    val imageUrl: String? = null,
-    @SerializedName("sequence_id")
-    val sequenceId: Long = 0,
-    @SerializedName("planter_photo_url")
-    val planterPhotoUrl: String? = null,
-    @SerializedName("planter_identifier")
-    val planterIdentifier: String? = null
-)
+data class NewTreeRequest(@SerializedName("user_id")
+                          val userId: Int = 0,
+                          @SerializedName("lat")
+                          val lat: Double = 0.toDouble(),
+                          @SerializedName("lon")
+                          val lon: Double = 0.toDouble(),
+                          @SerializedName("gps_accuracy")
+                          val gpsAccuracy: Int = 0,
+                          @SerializedName("note")
+                          val note: String? = null,
+                          @SerializedName("timestamp")
+                          val timestamp: Long = 0,
+                          @SerializedName("image_url")
+                          val imageUrl: String? = null,
+                          @SerializedName("sequence_id")
+                          val sequenceId: Long = 0,
+                          @SerializedName("planter_photo_url")
+                          val planterPhotoUrl: String? = null,
+                          @SerializedName("planter_identifier")
+                          val planterIdentifier: String? = null)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/RegistrationRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/RegistrationRequest.kt
@@ -2,18 +2,11 @@ package org.greenstand.android.TreeTracker.api.models.requests
 
 import com.google.gson.annotations.SerializedName
 
-class RegistrationRequest {
-
-    @SerializedName("planter_identifier")
-    var planterIdentifier: String? = null
-
-    @SerializedName("first_name")
-    var firstName: String? = null
-
-    @SerializedName("last_name")
-    var lastName: String? = null
-
-    @SerializedName("organization")
-    var organization: String? = null
-
-}
+data class RegistrationRequest(@SerializedName("planter_identifier")
+                               val planterIdentifier: String?,
+                               @SerializedName("first_name")
+                               val firstName: String?,
+                               @SerializedName("last_name")
+                               val lastName: String?,
+                               @SerializedName("organization")
+                               val organization: String?)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/responses/PostResult.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/responses/PostResult.kt
@@ -6,8 +6,5 @@ import com.google.gson.annotations.SerializedName
  * Created by lei on 11/10/17.
  */
 
-class PostResult {
-
-    @SerializedName("status")
-    var status: Int = 0
-}
+data class PostResult(@SerializedName("status")
+                      var status: Int = 0)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/responses/TokenResponse.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/responses/TokenResponse.kt
@@ -4,9 +4,6 @@ package org.greenstand.android.TreeTracker.api.models.responses
  * Created by zaven on 4/8/18.
  */
 
-class TokenResponse {
-    var token: String? = null
-    private val firstName: String? = null
-    private val lastName: String? = null
-
-}
+data class TokenResponse(val token: String? = null,
+                         private val firstName: String? = null,
+                         private val lastName: String? = null)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/responses/UserTree.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/responses/UserTree.kt
@@ -3,20 +3,20 @@ package org.greenstand.android.TreeTracker.api.models.responses
 import com.google.gson.annotations.SerializedName
 
 
-class UserTree {
-
-    @SerializedName("id")
-    var id: String? = null
-    @SerializedName("created")
-    var created: String? = null
-    @SerializedName("updated")
-    var updated: String? = null
-    @SerializedName("priority")
-    var priority: String? = null
-    @SerializedName("lat")
-    var lat: String? = null
-    @SerializedName("lng")
-    var lng: String? = null
+data class UserTree(@SerializedName("id")
+                    val id: String? = null,
+                    @SerializedName("created")
+                    val created: String? = null,
+                    @SerializedName("updated")
+                    val updated: String? = null,
+                    @SerializedName("priority")
+                    val priority: String? = null,
+                    @SerializedName("lat")
+                    val lat: String? = null,
+                    @SerializedName("lng")
+                    val lng: String? = null,
+                    @SerializedName("image_url")
+                    val imageUrl: String? = null)
     //    @SerializedName("gps")
     //    private String gps;
     //    @SerializedName("next_update")
@@ -36,7 +36,3 @@ class UserTree {
     //    public void setNextUpdate(String nextUpdate) {
     //        this.nextUpdate = nextUpdate;
     //    }
-
-    @SerializedName("image_url")
-    var imageUrl: String? = null
-}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
@@ -458,7 +458,7 @@ class DataFragment : Fragment(), View.OnClickListener {
 
         var treeCursor = TreeTrackerApplication.getDatabaseManager().queryCursor("SELECT COUNT(*) AS total FROM tree", null)
         treeCursor.moveToFirst()
-        totalTrees.text = treeCursor.getString(treeCursor.getColumnIndex("total"))
+        totalTrees.text = treeCursor.loadString("total")
         Timber.d("total ${treeCursor.loadString("total")}")
 
         /*treeCursor = mDatabaseManager.queryCursor("SELECT COUNT(*) AS updated FROM tree WHERE is_synced = 'Y' AND time_for_update < DATE('NOW')", null);
@@ -475,14 +475,14 @@ class DataFragment : Fragment(), View.OnClickListener {
         treeCursor = TreeTrackerApplication.getDatabaseManager()
                 .queryCursor("SELECT COUNT(*) AS located FROM tree WHERE is_synced = 'Y'", null)
         treeCursor.moveToFirst()
-        locatedTrees.text = treeCursor.getString(treeCursor.getColumnIndex("located"))
-        Timber.d("located " + treeCursor.getString(treeCursor.getColumnIndex("located")))
+        locatedTrees.text = treeCursor.loadString("located")
+        Timber.d("located ${treeCursor.loadString("located")}")
 
         treeCursor = TreeTrackerApplication.getDatabaseManager()
                 .queryCursor("SELECT COUNT(*) AS tosync FROM tree WHERE is_synced = 'N'", null)
         treeCursor.moveToFirst()
-        tosyncTrees.text = treeCursor.getString(treeCursor.getColumnIndex("tosync"))
-        Timber.d("to sync " + treeCursor.getString(treeCursor.getColumnIndex("tosync")))
+        tosyncTrees.text = treeCursor.loadString("tosync")
+        Timber.d("to sync ${treeCursor.loadString("tosync")}")
 
     }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
@@ -268,12 +268,14 @@ class DataFragment : Fragment(), View.OnClickListener {
     }
 
     private fun uploadPlanterRegistration(registrationsCursor: Cursor) = async {
-        val registration = RegistrationRequest(
-            planterIdentifier = registrationsCursor.loadString("identifier"),
-            firstName = registrationsCursor.loadString("first_name"),
-            lastName = registrationsCursor.loadString("last_name"),
-            organization = registrationsCursor.loadString("organization")
-        )
+        val registration = with(registrationsCursor) {
+            RegistrationRequest(
+                planterIdentifier = loadString("identifier"),
+                firstName = loadString("first_name"),
+                lastName = loadString("last_name"),
+                organization = loadString("organization")
+            )
+        }
 
         val result = Api.instance().api!!.createPlanterRegistration(registration).execute()
         if(result != null) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/CursorExtensions.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/CursorExtensions.kt
@@ -1,0 +1,8 @@
+package org.greenstand.android.TreeTracker.utilities
+
+import android.database.Cursor
+
+fun Cursor.loadString(id: String): String? = getString(getColumnIndex(id))
+fun Cursor.loadFloat(id: String): Float = getFloat(getColumnIndex(id))
+fun Cursor.loadLong(id: String): Long = getLong(getColumnIndex(id))
+fun Cursor.loadDouble(id: String): Double = getDouble(getColumnIndex(id))


### PR DESCRIPTION
Tested this on an emulator. From a clean app start created account. Took tree photo. Uploaded success. Took another photo. Uploaded, success.

Changes:
- Responses updated to idiomatic Kotlin
- Requests updated to idiomatic Kotlin
- Added extension function for the Cursor object to reduce boiler plate. Instead of calling `cursor.getString(cursor.getColumnIndex("my_key"))` we can call `cursor.loadString("my_key")`
- Minor code cleanup in areas like Api
- Moved NewTreeRequest creation into its own function. If creation fails, it returns null. uploadNextTreeAsync now accepts a successfully created request instead of creating it itself.

Time Spent: 45 min