### PR TITLE
Slack notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
         applicationId "org.greenstand.android.TreeTracker"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 80
+        versionCode 81
         versionName "1.2.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
         applicationId "org.greenstand.android.TreeTracker"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 79
+        versionCode 80
         versionName "1.2.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ android {
         applicationId "org.greenstand.android.TreeTracker"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 78
+        versionCode 79
         versionName "1.2.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ platform :android do
 
     versionReleased = bump_version_code()
 
-    git_commit(path: "./app/build.gradle", message: "Release to PLay Store: Version Bump to to " + versionReleased.to_s)
+    git_commit(path: "./app/build.gradle", message: "Release to Play Store: Version Bump to to " + versionReleased.to_s)
 
     add_git_tag()
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,6 @@ platform :android do
         slack_url: ENV["SLACK_URL_QC”],
         payload: {
                      "Build Number" => versionReleased,
-                     "Message" => "This is a test",
                    },
         default_payloads: ['git_branch'])
   
@@ -55,9 +54,9 @@ platform :android do
   desc "Submit a new JustDigIt Beta Build to Crashlytics Beta"
   lane :justdigit_beta do
   
-    bump_version_code()
+    versionReleased = bump_version_code()
 
-    git_commit(path: "./app/build.gradle", message: "Version Bump")
+    git_commit(path: "./app/build.gradle", message: "Version Bump to " + versionReleased.to_s)
 
     gradle(task: "clean assembleJustdigitDebug")
     crashlytics(groups: "all-testers")
@@ -67,6 +66,9 @@ platform :android do
 
     slack(message: "A new JustDigIt Beta Build has been released on Fabric",
         slack_url: ENV["SLACK_URL_QC”],
+        payload: {
+                     "Build Number" => versionReleased,
+                   },
         default_payloads: ['git_branch'])
   
   end
@@ -75,9 +77,9 @@ platform :android do
   desc "Deploy a new version to the Google Play"
   lane :deploy do
 
-    bump_version_code()
+    versionReleased = bump_version_code()
 
-    git_commit(path: "./app/build.gradle", message: "Release to PLay Store: Version Bump")
+    git_commit(path: "./app/build.gradle", message: "Release to PLay Store: Version Bump to to " + versionReleased.to_s)
 
     add_git_tag()
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ platform :android do
 
     versionReleased = bump_version_code()
 
-    git_commit(path: "./app/build.gradle", message: "Release to Play Store: Version Bump to to " + versionReleased.to_s)
+    git_commit(path: "./app/build.gradle", message: "Release to Play Store: Version Bump to " + versionReleased.to_s)
 
     add_git_tag()
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :android do
   
     versionReleased = bump_version_code()
 
-    git_commit(path: "./app/build.gradle", message: "Version Bump")
+    git_commit(path: "./app/build.gradle", message: "Version Bump to " + versionReleased.to_s)
 
     gradle(task: "clean assembleGreenstandDebug")
     crashlytics(groups: "all-testers")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,7 +31,7 @@ platform :android do
   desc "Submit a new Greenstand Beta Build to Crashlytics Beta"
   lane :beta do
   
-    bump_version_code()
+    versionReleased = bump_version_code()
 
     git_commit(path: "./app/build.gradle", message: "Version Bump")
 
@@ -43,6 +43,10 @@ platform :android do
 
     slack(message: "A new Greenstand Beta Build has been released on Fabric",
         slack_url: ENV["SLACK_URL_QC”],
+        payload: {
+                     "Build Number" => versionReleased,
+                     "Message" => "This is a test",
+                   },
         default_payloads: ['git_branch'])
   
   end
@@ -94,6 +98,8 @@ platform :android do
     f = File.new(path, 'w')
     f.write(s)
     f.close
+
+    versionCode += 1
   end
 end
 


### PR DESCRIPTION
These changes will add the build number to the slack messages whenever a new build is generated and sent either to Fabric or the Play Store.