### PR TITLE
Tree Data UI changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -263,6 +263,7 @@ dependencies {
     api 'com.google.firebase:firebase-core:16.0.6'
 
     implementation "androidx.legacy:legacy-support-v4:${androidSupportVersion}"
+    implementation 'com.android.support:cardview-v7:28.0.0'
 }
 configurations.all {
     resolutionStrategy {

--- a/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/2.json
+++ b/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/2.json
@@ -2,61 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "15348b337f92600443a71188434c46e7",
+    "identityHash": "ca1519d8eee4b97bbdf643112b6eaa43",
     "entities": [
       {
-        "tableName": "tree_attributes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `tree_id` INTEGER NOT NULL, FOREIGN KEY(`tree_id`) REFERENCES `tree`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "key",
-            "columnName": "key",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "value",
-            "columnName": "value",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "treeId",
-            "columnName": "tree_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "_id"
-          ],
-          "autoGenerate": true
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "tree",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "tree_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "tree",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uuid` TEXT, `main_db_id` INTEGER NOT NULL, `time_created` TEXT NOT NULL, `time_updated` TEXT NOT NULL, `time_for_update` TEXT NOT NULL, `three_digit_number` INTEGER, `location_id` INTEGER, `is_missing` INTEGER NOT NULL, `is_synced` INTEGER NOT NULL, `is_priority` INTEGER NOT NULL, `cause_of_death_id` INTEGER, `settings_id` INTEGER, `settings_override_id` INTEGER, `user_id` INTEGER, `planter_identification_id` INTEGER, FOREIGN KEY(`settings_override_id`) REFERENCES `settings`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`settings_id`) REFERENCES `settings`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`location_id`) REFERENCES `location`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`cause_of_death_id`) REFERENCES `note`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`planter_identification_id`) REFERENCES `planter_identifications`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "tableName": "planter_check_in",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planter_info_id` INTEGER NOT NULL, `local_photo_path` TEXT NOT NULL, `photo_url` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`planter_info_id`) REFERENCES `planter_info`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "id",
@@ -65,298 +15,38 @@
             "notNull": true
           },
           {
-            "fieldPath": "uuid",
-            "columnName": "uuid",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "mainDbId",
-            "columnName": "main_db_id",
+            "fieldPath": "planterInfoId",
+            "columnName": "planter_info_id",
             "affinity": "INTEGER",
             "notNull": true
           },
           {
-            "fieldPath": "timeCreated",
-            "columnName": "time_created",
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
             "affinity": "TEXT",
             "notNull": true
           },
           {
-            "fieldPath": "timeUpdated",
-            "columnName": "time_updated",
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
             "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "timeForUpdate",
-            "columnName": "time_for_update",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "threeDigitNumber",
-            "columnName": "three_digit_number",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "locationId",
-            "columnName": "location_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "isMissing",
-            "columnName": "is_missing",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "isSynced",
-            "columnName": "is_synced",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "isPriority",
-            "columnName": "is_priority",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "causeOfDeath",
-            "columnName": "cause_of_death_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "settingId",
-            "columnName": "settings_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "settingsOverrideId",
-            "columnName": "settings_override_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "userId",
-            "columnName": "user_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "planterId",
-            "columnName": "planter_identification_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "_id"
-          ],
-          "autoGenerate": true
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "settings",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "settings_override_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "settings",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "settings_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "location",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "location_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "note",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "cause_of_death_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "planter_identifications",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "planter_identification_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "tree_note",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`note_id` INTEGER NOT NULL, `tree_id` INTEGER NOT NULL, PRIMARY KEY(`note_id`, `tree_id`), FOREIGN KEY(`note_id`) REFERENCES `note`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`tree_id`) REFERENCES `tree`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
-        "fields": [
-          {
-            "fieldPath": "noteId",
-            "columnName": "note_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "treeId",
-            "columnName": "tree_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "note_id",
-            "tree_id"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "note",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "note_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "tree",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "tree_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "tree_photo",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tree_id` INTEGER NOT NULL, `photo_id` INTEGER NOT NULL, PRIMARY KEY(`tree_id`, `photo_id`), FOREIGN KEY(`photo_id`) REFERENCES `photo`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`tree_id`) REFERENCES `tree`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
-        "fields": [
-          {
-            "fieldPath": "treeId",
-            "columnName": "tree_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "photoId",
-            "columnName": "photo_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "tree_id",
-            "photo_id"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "photo",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "photo_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "tree",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "tree_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "location",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `accuracy` INTEGER, `lat` REAL, `long` REAL, `user_id` INTEGER, `main_db_id` INTEGER NOT NULL)",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "accuracy",
-            "columnName": "accuracy",
-            "affinity": "INTEGER",
             "notNull": false
           },
           {
             "fieldPath": "latitude",
-            "columnName": "lat",
+            "columnName": "latitude",
             "affinity": "REAL",
-            "notNull": false
+            "notNull": true
           },
           {
             "fieldPath": "longitude",
-            "columnName": "long",
+            "columnName": "longitude",
             "affinity": "REAL",
-            "notNull": false
+            "notNull": true
           },
           {
-            "fieldPath": "userId",
-            "columnName": "user_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "mainDbId",
-            "columnName": "main_db_id",
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
             "affinity": "INTEGER",
             "notNull": true
           }
@@ -367,56 +57,33 @@
           ],
           "autoGenerate": true
         },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "note",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `main_db_id` INTEGER NOT NULL, `content` TEXT, `time_created` TEXT NOT NULL, `user_id` INTEGER)",
-        "fields": [
+        "indices": [
           {
-            "fieldPath": "id",
-            "columnName": "_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "mainDbId",
-            "columnName": "main_db_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "content",
-            "columnName": "content",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "timeCreated",
-            "columnName": "time_created",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "userId",
-            "columnName": "user_id",
-            "affinity": "INTEGER",
-            "notNull": false
+            "name": "index_planter_check_in_planter_info_id",
+            "unique": false,
+            "columnNames": [
+              "planter_info_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_check_in_planter_info_id` ON `${TABLE_NAME}` (`planter_info_id`)"
           }
         ],
-        "primaryKey": {
-          "columnNames": [
-            "_id"
-          ],
-          "autoGenerate": true
-        },
-        "indices": [],
-        "foreignKeys": []
+        "foreignKeys": [
+          {
+            "table": "planter_info",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_info_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
       },
       {
-        "tableName": "planter_details",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `identifier` TEXT, `first_name` TEXT, `last_name` TEXT, `organization` TEXT, `phone` TEXT, `email` TEXT, `uploaded` INTEGER NOT NULL, `time_created` TEXT NOT NULL, `location` TEXT)",
+        "tableName": "planter_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planterInfoId` TEXT NOT NULL, `first_name` TEXT NOT NULL, `last_name` TEXT NOT NULL, `organization` TEXT, `phone` TEXT, `email` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -426,21 +93,21 @@
           },
           {
             "fieldPath": "identifier",
-            "columnName": "identifier",
+            "columnName": "planterInfoId",
             "affinity": "TEXT",
-            "notNull": false
+            "notNull": true
           },
           {
             "fieldPath": "firstName",
             "columnName": "first_name",
             "affinity": "TEXT",
-            "notNull": false
+            "notNull": true
           },
           {
             "fieldPath": "lastName",
             "columnName": "last_name",
             "affinity": "TEXT",
-            "notNull": false
+            "notNull": true
           },
           {
             "fieldPath": "organization",
@@ -461,22 +128,28 @@
             "notNull": false
           },
           {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
             "fieldPath": "uploaded",
             "columnName": "uploaded",
             "affinity": "INTEGER",
             "notNull": true
           },
           {
-            "fieldPath": "timeCreated",
-            "columnName": "time_created",
-            "affinity": "TEXT",
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
             "notNull": true
-          },
-          {
-            "fieldPath": "location",
-            "columnName": "location",
-            "affinity": "TEXT",
-            "notNull": false
           }
         ],
         "primaryKey": {
@@ -489,8 +162,58 @@
         "foreignKeys": []
       },
       {
-        "tableName": "planter_identifications",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planter_details_id` INTEGER, `identifier` TEXT, `photo_path` TEXT, `photo_url` TEXT, `time_created` TEXT NOT NULL, `location` TEXT, FOREIGN KEY(`planter_details_id`) REFERENCES `planter_details`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "tableName": "planter_account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`planter_info_id` INTEGER NOT NULL, `uploaded_tree_count` INTEGER NOT NULL, `validated_tree_count` INTEGER NOT NULL, `total_amount_paid` REAL NOT NULL, `payment_amount_pending` REAL NOT NULL, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`planter_info_id`))",
+        "fields": [
+          {
+            "fieldPath": "planterInfoId",
+            "columnName": "planter_info_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadedTreeCount",
+            "columnName": "uploaded_tree_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "validatedTreeCount",
+            "columnName": "validated_tree_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmountPaid",
+            "columnName": "total_amount_paid",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentAmountPending",
+            "columnName": "payment_amount_pending",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "planter_info_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tree_attribute",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `tree_capture_id` INTEGER NOT NULL, FOREIGN KEY(`tree_capture_id`) REFERENCES `tree_capture`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "id",
@@ -499,20 +222,79 @@
             "notNull": true
           },
           {
-            "fieldPath": "planterDetailsId",
-            "columnName": "planter_details_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "identifier",
-            "columnName": "identifier",
+            "fieldPath": "key",
+            "columnName": "key",
             "affinity": "TEXT",
-            "notNull": false
+            "notNull": true
           },
           {
-            "fieldPath": "photoPath",
-            "columnName": "photo_path",
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeCaptureId",
+            "columnName": "tree_capture_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_attribute_tree_capture_id",
+            "unique": false,
+            "columnNames": [
+              "tree_capture_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_attribute_tree_capture_id` ON `${TABLE_NAME}` (`tree_capture_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tree_capture",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tree_capture_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tree_capture",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uuid` TEXT NOT NULL, `planter_checkin_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `note_content` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `accuracy` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, FOREIGN KEY(`planter_checkin_id`) REFERENCES `planter_check_in`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planterCheckInId",
+            "columnName": "planter_checkin_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
             "affinity": "TEXT",
             "notNull": false
           },
@@ -523,14 +305,44 @@
             "notNull": false
           },
           {
-            "fieldPath": "timeCreated",
-            "columnName": "time_created",
+            "fieldPath": "noteContent",
+            "columnName": "note_content",
             "affinity": "TEXT",
             "notNull": true
           },
           {
-            "fieldPath": "location",
-            "columnName": "location",
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
             "affinity": "TEXT",
             "notNull": false
           }
@@ -541,210 +353,23 @@
           ],
           "autoGenerate": true
         },
-        "indices": [],
+        "indices": [
+          {
+            "name": "index_tree_capture_planter_checkin_id",
+            "unique": false,
+            "columnNames": [
+              "planter_checkin_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_planter_checkin_id` ON `${TABLE_NAME}` (`planter_checkin_id`)"
+          }
+        ],
         "foreignKeys": [
           {
-            "table": "planter_details",
+            "table": "planter_check_in",
             "onDelete": "NO ACTION",
             "onUpdate": "CASCADE",
             "columns": [
-              "planter_details_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "settings",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `main_db_id` INTEGER NOT NULL, `time_to_next_update` INTEGER NOT NULL, `min_accuracy` INTEGER NOT NULL)",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "mainDbId",
-            "columnName": "main_db_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "timeToNextUpdate",
-            "columnName": "time_to_next_update",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "minAccuracy",
-            "columnName": "min_accuracy",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "_id"
-          ],
-          "autoGenerate": true
-        },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "pending_updates",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `main_db_id` INTEGER NOT NULL, `user_id` INTEGER, `settings_id` INTEGER, `tree_id` INTEGER, `location_id` INTEGER, `radius` INTEGER, FOREIGN KEY(`settings_id`) REFERENCES `settings`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`tree_id`) REFERENCES `tree`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION , FOREIGN KEY(`location_id`) REFERENCES `location`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "mainDbId",
-            "columnName": "main_db_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "userId",
-            "columnName": "user_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "settingsId",
-            "columnName": "settings_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "treeId",
-            "columnName": "tree_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "locationId",
-            "columnName": "location_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "radius",
-            "columnName": "radius",
-            "affinity": "INTEGER",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "_id"
-          ],
-          "autoGenerate": true
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "settings",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "settings_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "tree",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "tree_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          },
-          {
-            "table": "location",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "location_id"
-            ],
-            "referencedColumns": [
-              "_id"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "photo",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `location_id` INTEGER, `main_db_id` INTEGER NOT NULL, `is_outdated` INTEGER NOT NULL, `time_taken` TEXT NOT NULL, `user_id` INTEGER, FOREIGN KEY(`location_id`) REFERENCES `location`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "name",
-            "columnName": "name",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "locationId",
-            "columnName": "location_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "mainDbId",
-            "columnName": "main_db_id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "isOutdated",
-            "columnName": "is_outdated",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "timeTaken",
-            "columnName": "time_taken",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "userId",
-            "columnName": "user_id",
-            "affinity": "INTEGER",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "_id"
-          ],
-          "autoGenerate": true
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "location",
-            "onDelete": "NO ACTION",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "location_id"
+              "planter_checkin_id"
             ],
             "referencedColumns": [
               "_id"
@@ -753,9 +378,10 @@
         ]
       }
     ],
+    "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"15348b337f92600443a71188434c46e7\")"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ca1519d8eee4b97bbdf643112b6eaa43')"
     ]
   }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
@@ -4,19 +4,18 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import org.greenstand.android.TreeTracker.database.entity.PlanterCheckInEntity
-import org.greenstand.android.TreeTracker.database.entity.PlanterInfoEntity
-import org.greenstand.android.TreeTracker.database.entity.TreeAttributeEntity
-import org.greenstand.android.TreeTracker.database.entity.TreeCaptureEntity
+import org.greenstand.android.TreeTracker.database.entity.*
+
 
 @Database(
     entities = [
         PlanterCheckInEntity::class,
         PlanterInfoEntity::class,
+        PlanterAccountEntity::class,
         TreeAttributeEntity::class,
         TreeCaptureEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -34,6 +33,7 @@ abstract class AppDatabase : RoomDatabase() {
                                                     AppDatabase::class.java,
                                                     DB_NAME
                     )
+                        .addMigrations(MIGRATION_1_2)
                         .build()
                 }
             }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/Migrations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/Migrations.kt
@@ -1,0 +1,15 @@
+package org.greenstand.android.TreeTracker.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2 = object : Migration(1,2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        val sql = """CREATE TABLE `planter_account` (`planter_info_id` INTEGER PRIMARY KEY NOT NULL,
+            |`uploaded_tree_count` INTEGER NOT NULL, `validated_tree_count` INTEGER NOT NULL, 
+            |`total_amount_paid` REAL NOT NULL, `payment_amount_pending` REAL NOT NULL,
+            |`updated_at` INTEGER NOT NULL)
+        """.trimMargin()
+        database.execSQL(sql)
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
@@ -1,10 +1,7 @@
 package org.greenstand.android.TreeTracker.database
 
 import androidx.room.*
-import org.greenstand.android.TreeTracker.database.entity.PlanterCheckInEntity
-import org.greenstand.android.TreeTracker.database.entity.PlanterInfoEntity
-import org.greenstand.android.TreeTracker.database.entity.TreeAttributeEntity
-import org.greenstand.android.TreeTracker.database.entity.TreeCaptureEntity
+import org.greenstand.android.TreeTracker.database.entity.*
 import org.greenstand.android.TreeTracker.database.views.TreeMapMarkerDbView
 
 
@@ -29,7 +26,8 @@ interface TreeTrackerDAO {
     @Delete
     fun deletePlanterInfo(planterInfoEntity: PlanterInfoEntity)
 
-
+    @Query("SELECT * FROM planter_account WHERE planter_info_id = :planterInfoId")
+    fun getPlanterAccount(planterInfoId: Long): PlanterAccountEntity
 
     @Transaction
     @Query("SELECT * FROM planter_check_in WHERE photo_url IS null AND planter_info_id = :planterInfoId")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/PlanterAccountEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/PlanterAccountEntity.kt
@@ -1,0 +1,35 @@
+package org.greenstand.android.TreeTracker.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+@Entity(
+    tableName = PlanterAccountEntity.TABLE
+)
+data class PlanterAccountEntity(
+    @PrimaryKey
+    @ColumnInfo(name= PLANTER_INFO_ID)
+    val planterInfoId: Int,
+    @ColumnInfo(name = UPLOADED_TREE_COUNT)
+    val uploadedTreeCount: Int,
+    @ColumnInfo(name = VALIDATED_TREE_COUNT)
+    val validatedTreeCount: Int,
+    @ColumnInfo(name = TOTAL_AMOUNT_PAID)
+    val totalAmountPaid: Double,
+    @ColumnInfo(name = PAYMENT_AMOUNT_PENDING)
+    val paymentAmountPending: Double,
+    @ColumnInfo(name = UPDATED_AT)
+    val updatedAt: Long
+) {
+    companion object {
+        const val TABLE = "planter_account"
+
+        const val PLANTER_INFO_ID = "planter_info_id"
+        const val UPLOADED_TREE_COUNT = "uploaded_tree_count"
+        const val VALIDATED_TREE_COUNT = "validated_tree_count"
+        const val TOTAL_AMOUNT_PAID = "total_amount_paid"
+        const val PAYMENT_AMOUNT_PENDING = "payment_amount_pending"
+        const val UPDATED_AT = "updated_at"
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
@@ -30,7 +30,7 @@ val appModule = module {
 
     viewModel { TreeHeightViewModel(get(), get(), get()) }
 
-    viewModel { DataViewModel(get(), get(), get(), get()) }
+    viewModel { DataViewModel(get(), get(), get(), get(), get()) }
 
     viewModel { MapViewModel(get(), get(), get(), get(), get()) }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
@@ -16,6 +16,7 @@ import kotlinx.android.synthetic.main.fragment_data.*
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.viewmodels.DataViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
+import java.util.*
 
 class DataFragment : Fragment() {
 
@@ -48,12 +49,12 @@ class DataFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.planterAccountData.observe(this, Observer { planterAccountData ->
-            val treeData = planterAccountData.treeData
-            fragmentDataUploaded.text = treeData.uploadedCount.toString()
-            fragmentDataWaitingUpload.text = treeData.waitingToUploadCount.toString()
-            fragmentDataValidatedTrees.text = treeData.validatedCount.toString()
-            paymentPendingValue.text = planterAccountData.paymentAmountPending.toString()
-            totalPaidValue.text = planterAccountData.totalAmountPaid.toString()
+            val currencySymbol = Currency.getInstance(planterAccountData.paymentCurrencyCode).symbol
+            fragmentDataUploaded.text = planterAccountData.uploadedCount.toString()
+            fragmentDataWaitingUpload.text = planterAccountData.waitingToUploadCount.toString()
+            fragmentDataValidatedTrees.text = planterAccountData.validatedCount.toString()
+            paymentPendingValue.text = "$currencySymbol${planterAccountData.paymentAmountPending.toString()}"
+            totalPaidValue.text = "$currencySymbol${planterAccountData.totalAmountPaid.toString()}"
         })
 
         viewModel.toasts.observe(this, Observer {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/DataFragment.kt
@@ -2,7 +2,10 @@ package org.greenstand.android.TreeTracker.fragments
 
 
 import android.os.Bundle
-import android.view.*
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.View
+import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -44,10 +47,13 @@ class DataFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        viewModel.treeData.observe(this, Observer { treeData ->
-            fragmentDataTotalTreesValue.text = treeData.totalTrees.toString()
-            fragmentDataLocatedValue.text = treeData.treesSynced.toString()
-            fragmentDataToSyncValue.text = treeData.treesToSync.toString()
+        viewModel.planterAccountData.observe(this, Observer { planterAccountData ->
+            val treeData = planterAccountData.treeData
+            fragmentDataUploaded.text = treeData.uploadedCount.toString()
+            fragmentDataWaitingUpload.text = treeData.waitingToUploadCount.toString()
+            fragmentDataValidatedTrees.text = treeData.validatedCount.toString()
+            paymentPendingValue.text = planterAccountData.paymentAmountPending.toString()
+            totalPaidValue.text = planterAccountData.totalAmountPaid.toString()
         })
 
         viewModel.toasts.observe(this, Observer {
@@ -55,14 +61,11 @@ class DataFragment : Fragment() {
         })
 
         viewModel.isSyncing.observe(this, Observer { isSyncing ->
-            val textId = if (isSyncing) {
-                requireActivity().window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-                R.string.stop
+            if (isSyncing) {
+                fragmentDataSyncButton.setImageResource(R.drawable.stop_40dp)
             } else {
-                requireActivity().window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-                R.string.sync
+                fragmentDataSyncButton.setImageResource(R.drawable.cloud_backup_40)
             }
-            fragmentDataSyncButton.setText(textId)
         })
 
         fragmentDataSyncButton.setOnClickListener {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserManager.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserManager.kt
@@ -27,9 +27,12 @@ class UserManager(private val context: Context,
         get() = sharedPreferences.getString(ORG_NAME_KEY, null)
         set(value) = sharedPreferences.edit().putString(ORG_NAME_KEY, value).apply()
 
-    var planterCheckinId: Long?
+    var planterCheckinId: Long
         get() = sharedPreferences.getLong(ValueHelper.PLANTER_CHECK_IN_ID, -1)
         set(value) = sharedPreferences.edit().putLong(ValueHelper.PLANTER_CHECK_IN_ID, value ?: -1).apply()
+
+    val planterInfoId: Long
+        get() = sharedPreferences.getLong(ValueHelper.PLANTER_INFO_ID, -1)
 
     fun clearUser() {
         sharedPreferences.edit().apply {

--- a/app/src/main/res/drawable/circle_upload_button.xml
+++ b/app/src/main/res/drawable/circle_upload_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@color/green" />
+    <size android:width="80dp" android:height="80dp"/>
+</shape>

--- a/app/src/main/res/drawable/cloud_backup_40.xml
+++ b/app/src/main/res/drawable/cloud_backup_40.xml
@@ -1,0 +1,4 @@
+<vector android:height="40dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l4.65,-4.65c0.2,-0.2 0.51,-0.2 0.71,0L17,13h-3z"/>
+</vector>

--- a/app/src/main/res/drawable/stop_40dp.xml
+++ b/app/src/main/res/drawable/stop_40dp.xml
@@ -1,0 +1,4 @@
+<vector android:height="40dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="40dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M6,6h12v12H6z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_data.xml
+++ b/app/src/main/res/layout/fragment_data.xml
@@ -162,7 +162,6 @@
             android:id="@+id/payment_data_layout"
             android:layout_width="match_parent"
             android:layout_height="120dp"
-            android:layout_marginStart="16dp"
             android:paddingLeft="@dimen/sixteen_dp"
             android:paddingTop="@dimen/padding_five"
             android:paddingRight="@dimen/sixteen_dp"

--- a/app/src/main/res/layout/fragment_data.xml
+++ b/app/src/main/res/layout/fragment_data.xml
@@ -1,132 +1,249 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-				xmlns:tools="http://schemas.android.com/tools"
-				android:id="@+id/fragment_data"
-				android:layout_width="match_parent"
-				android:layout_height="match_parent"
-				android:background="@color/background"
-				android:orientation="vertical">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment_data"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/lightGrey"
+    android:orientation="vertical">
 
-    <ImageView
-        android:id="@+id/fragment_data_logo"
-		android:layout_width="@dimen/logo_width"
-		android:layout_height="157dp"
-		android:layout_centerHorizontal="true"
-        android:layout_alignParentTop="true"
-		tools:src="@drawable/logo"
-        android:contentDescription="@string/app_name"
-        android:src="@drawable/logo"
-		android:layout_marginTop="@dimen/twenty_eight_dp"
-		/>
-
-    <LinearLayout
-        android:id="@+id/fragment_data_total_trees"
+    <TextView
+        android:id="@+id/fragment_data_title"
+        style="@style/TextTitleStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/fragment_data_logo"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/padding_forty_eight"
-        android:paddingTop="@dimen/padding_five"
-        android:paddingRight="@dimen/padding_forty_eight"
-        android:paddingBottom="@dimen/padding_five">
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/tree_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="@dimen/height_forty"
-            android:layout_marginTop="@dimen/margin_twelve"
-            android:layout_weight="3"
-            android:text="@string/total_trees"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_size_seventeen" />
-
-        <TextView
-            android:id="@+id/fragmentDataTotalTreesValue"
-            android:layout_width="0dp"
-            android:layout_height="@dimen/height_forty"
-            android:layout_marginTop="@dimen/margin_twelve"
-            android:layout_weight="1"
-            android:gravity="end"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_size_seventeen" />
-
-    </LinearLayout>
-
-
-    <LinearLayout
-        android:id="@+id/fragment_data_located"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/tree_data_card_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/fragment_data_total_trees"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/padding_forty_eight"
-        android:paddingTop="@dimen/padding_five"
-        android:paddingRight="@dimen/padding_forty_eight"
-        android:paddingBottom="@dimen/padding_five">
+        android:layout_below="@+id/fragment_data_title"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        app:cardBackgroundColor="@color/white"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/fragment_data_title">
 
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="@dimen/height_forty"
-            android:layout_marginTop="@dimen/margin_twelve"
-            android:layout_weight="3"
-            android:text="@string/uploaded"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_size_seventeen" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/tree_data_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="@dimen/sixteen_dp"
+            android:paddingTop="@dimen/padding_five"
+            android:paddingRight="@dimen/sixteen_dp"
+            android:paddingBottom="@dimen/padding_five">
 
-        <TextView
-            android:id="@+id/fragmentDataLocatedValue"
-            android:layout_width="0dp"
-            android:layout_height="@dimen/height_forty"
-            android:layout_marginTop="@dimen/margin_twelve"
-            android:layout_weight="1"
-            android:gravity="end"
-            android:textColor="@color/black"
-            android:textSize="@dimen/text_size_seventeen" />
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/tree_data_guideline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="243dp" />
 
-    </LinearLayout>
+            <TextView
+                android:id="@+id/fragmentDataUploadedLabel"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginStart="5dp"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:text="@string/uploaded"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
-        android:id="@+id/fragment_data_to_sync"
+            <TextView
+                android:id="@+id/fragmentDataUploaded"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:textColor="@color/black"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/tree_data_guideline"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/fragmentDataWaitingUploadLabel"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:text="@string/fragment_data_waiting_to_upload_label"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/fragmentDataUploadedLabel"
+                app:layout_constraintTop_toBottomOf="@+id/fragmentDataUploadedLabel" />
+
+            <TextView
+                android:id="@+id/fragmentDataWaitingUpload"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:textColor="@color/black"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/fragmentDataUploaded"
+                app:layout_constraintTop_toBottomOf="@+id/fragmentDataUploaded" />
+
+            <TextView
+                android:id="@+id/fragmentDataValidatedTreesLabel"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:text="@string/fragment_data_validated_label"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/fragmentDataWaitingUploadLabel"
+                app:layout_constraintTop_toBottomOf="@+id/fragmentDataWaitingUploadLabel" />
+
+            <TextView
+                android:id="@+id/fragmentDataValidatedTrees"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:textColor="@color/black"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/fragmentDataWaitingUpload"
+                app:layout_constraintTop_toBottomOf="@+id/fragmentDataWaitingUpload" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/fragment_data_payments_label"
+        style="@style/TextTitleStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/fragment_data_located"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/padding_forty_eight"
-        android:paddingTop="@dimen/padding_five"
-        android:paddingRight="@dimen/padding_forty_eight"
-        android:paddingBottom="@dimen/padding_five">
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:text="@string/payment_label"
+        app:layout_constraintEnd_toEndOf="@id/tree_data_card_view"
+        app:layout_constraintStart_toStartOf="@id/tree_data_card_view"
+        app:layout_constraintTop_toBottomOf="@+id/tree_data_card_view" />
 
-       	<TextView
-	    	android:layout_width="0dp"
-	        android:layout_height="@dimen/height_forty"
-	        android:textSize="@dimen/text_size_seventeen"
-	        android:layout_weight="3"
-	        android:textColor="@color/black"
-	        android:layout_marginTop="@dimen/margin_twenty"
-	        android:text="@string/to_sync"
-        />
-       	
-       	<TextView
-       	    android:id="@+id/fragmentDataToSyncValue"
-	    	android:layout_width="0dp"
-	        android:layout_height="@dimen/height_forty"
-	        android:textSize="@dimen/text_size_seventeen"
-	        android:layout_weight="1"
-	        android:gravity="right"
-	        android:textColor="@color/black"
-	        android:layout_marginTop="@dimen/margin_twenty"
-        />
-	    
-	</LinearLayout>	        
+    <androidx.cardview.widget.CardView
+        android:id="@+id/payment_data_card_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tree_data_card_view"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        app:cardBackgroundColor="@color/white"
+        app:cardCornerRadius="20dp"
+        app:cardElevation="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/fragment_data_payments_label">
 
-	    <Button
-	        android:id="@+id/fragmentDataSyncButton"
-	    	android:layout_width="match_parent"
-	        android:layout_height="wrap_content"
-	        android:layout_margin="@dimen/activity_vertical_margin"
-	        android:text="@string/sync"
-			style="@style/NewButtonStyle"
-	        android:layout_alignParentBottom="true"/>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/payment_data_layout"
+            android:layout_width="match_parent"
+            android:layout_height="120dp"
+            android:layout_marginStart="16dp"
+            android:paddingLeft="@dimen/sixteen_dp"
+            android:paddingTop="@dimen/padding_five"
+            android:paddingRight="@dimen/sixteen_dp"
+            android:paddingBottom="@dimen/padding_five">
 
-      
-</RelativeLayout>
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/paymentDataGuideline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="243dp" />
+
+            <TextView
+                android:id="@+id/paymentPendingLabel"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginStart="5dp"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:text="@string/pending_label"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/paymentPendingValue"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:textColor="@color/black"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/paymentDataGuideline"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/totalPaidLabel"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:text="@string/total_paid_label"
+                android:textColor="@color/black"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/paymentPendingLabel"
+                app:layout_constraintTop_toBottomOf="@+id/paymentPendingLabel" />
+
+            <TextView
+                android:id="@+id/totalPaidValue"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/height_forty"
+                android:layout_marginTop="16dp"
+                android:layout_weight="3"
+                android:textColor="@color/black"
+                android:textIsSelectable="true"
+                android:textSize="@dimen/text_size_seventeen"
+                app:layout_constraintStart_toStartOf="@+id/paymentDataGuideline"
+                app:layout_constraintTop_toBottomOf="@+id/paymentPendingValue" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+
+    <ImageButton
+        android:id="@+id/fragmentDataSyncButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_margin="@dimen/activity_vertical_margin"
+        android:layout_marginStart="307dp"
+        android:layout_marginEnd="307dp"
+        android:layout_marginBottom="16dp"
+        android:background="@drawable/circle_upload_button"
+        android:elevation="20dp"
+        android:foregroundGravity="center"
+        android:src="@drawable/cloud_backup_40"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_data.xml
+++ b/app/src/main/res/layout/fragment_data.xml
@@ -5,7 +5,7 @@
     android:id="@+id/fragment_data"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/lightGrey"
+    android:background="@color/background"
     android:orientation="vertical">
 
     <TextView
@@ -13,25 +13,25 @@
         style="@style/TextTitleStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="@dimen/title_margin_start"
+        android:layout_marginTop="@dimen/title_margin_top"
+        android:layout_marginEnd="@dimen/title_margin_end"
         android:text="@string/tree_title"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/tree_data_card_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/fragment_data_title"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="@dimen/card_view_margin_start"
+        android:layout_marginTop="@dimen/card_view_margin_top"
+        android:layout_marginEnd="@dimen/card_view_margin_end"
         app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="20dp"
-        app:cardElevation="10dp"
+        app:cardCornerRadius="@dimen/card_view_corner_radius"
+        app:cardElevation="@dimen/card_view_elevation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/fragment_data_title">
@@ -54,77 +54,71 @@
 
             <TextView
                 android:id="@+id/fragmentDataUploadedLabel"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginStart="5dp"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginStart="@dimen/data_text_margin_start"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:text="@string/uploaded"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 android:textColor="@color/black"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/fragmentDataUploaded"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:textColor="@color/black"
-                android:textIsSelectable="true"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/tree_data_guideline"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="540891" />
 
             <TextView
                 android:id="@+id/fragmentDataWaitingUploadLabel"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:text="@string/fragment_data_waiting_to_upload_label"
                 android:textColor="@color/black"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/fragmentDataUploadedLabel"
                 app:layout_constraintTop_toBottomOf="@+id/fragmentDataUploadedLabel" />
 
             <TextView
                 android:id="@+id/fragmentDataWaitingUpload"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:textColor="@color/black"
-                android:textIsSelectable="true"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/fragmentDataUploaded"
-                app:layout_constraintTop_toBottomOf="@+id/fragmentDataUploaded" />
+                app:layout_constraintTop_toBottomOf="@+id/fragmentDataUploaded"
+                tools:text="35" />
 
             <TextView
                 android:id="@+id/fragmentDataValidatedTreesLabel"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:text="@string/fragment_data_validated_label"
                 android:textColor="@color/black"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/fragmentDataWaitingUploadLabel"
                 app:layout_constraintTop_toBottomOf="@+id/fragmentDataWaitingUploadLabel" />
 
             <TextView
                 android:id="@+id/fragmentDataValidatedTrees"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:textColor="@color/black"
-                android:textIsSelectable="true"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/fragmentDataWaitingUpload"
-                app:layout_constraintTop_toBottomOf="@+id/fragmentDataWaitingUpload" />
+                app:layout_constraintTop_toBottomOf="@+id/fragmentDataWaitingUpload"
+                tools:text="450" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -135,9 +129,9 @@
         style="@style/TextTitleStyle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="@dimen/title_margin_start"
+        android:layout_marginTop="@dimen/title_margin_top"
+        android:layout_marginEnd="@dimen/title_margin_end"
         android:text="@string/payment_label"
         app:layout_constraintEnd_toEndOf="@id/tree_data_card_view"
         app:layout_constraintStart_toStartOf="@id/tree_data_card_view"
@@ -148,12 +142,12 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/tree_data_card_view"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginStart="@dimen/card_view_margin_start"
+        android:layout_marginTop="@dimen/card_view_margin_top"
+        android:layout_marginEnd="@dimen/card_view_margin_end"
         app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="20dp"
-        app:cardElevation="10dp"
+        app:cardCornerRadius="@dimen/card_view_corner_radius"
+        app:cardElevation="@dimen/card_view_elevation"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/fragment_data_payments_label">
@@ -176,53 +170,49 @@
 
             <TextView
                 android:id="@+id/paymentPendingLabel"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginStart="5dp"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginStart="@dimen/data_text_margin_start"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:text="@string/pending_label"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 android:textColor="@color/black"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/paymentPendingValue"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:textColor="@color/black"
-                android:textIsSelectable="true"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/paymentDataGuideline"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="$42.76"/>
 
             <TextView
                 android:id="@+id/totalPaidLabel"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:text="@string/total_paid_label"
                 android:textColor="@color/black"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/paymentPendingLabel"
                 app:layout_constraintTop_toBottomOf="@+id/paymentPendingLabel" />
 
             <TextView
                 android:id="@+id/totalPaidValue"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/height_forty"
-                android:layout_marginTop="16dp"
-                android:layout_weight="3"
+                android:layout_width="@dimen/data_text_layout_width"
+                android:layout_height="@dimen/data_text_layout_height"
+                android:layout_marginTop="@dimen/data_text_margin_top"
                 android:textColor="@color/black"
-                android:textIsSelectable="true"
-                android:textSize="@dimen/text_size_seventeen"
+                android:textSize="@dimen/data_text_size"
                 app:layout_constraintStart_toStartOf="@+id/paymentDataGuideline"
-                app:layout_constraintTop_toBottomOf="@+id/paymentPendingValue" />
+                app:layout_constraintTop_toBottomOf="@+id/paymentPendingValue"
+                tools:text="$251.25"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>
@@ -233,11 +223,11 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/activity_vertical_margin"
-        android:layout_marginStart="307dp"
-        android:layout_marginEnd="307dp"
-        android:layout_marginBottom="16dp"
+        android:layout_marginStart="@dimen/button_margin"
+        android:layout_marginEnd="@dimen/button_margin"
+        android:layout_marginBottom="@dimen/button_margin_bottom"
         android:background="@drawable/circle_upload_button"
-        android:elevation="20dp"
+        android:elevation="@dimen/button_elevation"
         android:foregroundGravity="center"
         android:src="@drawable/cloud_backup_40"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -249,6 +249,13 @@
         Ni nia yetu ya kushikilia kanuni za sera hii,lakini tunaelewa kunawezakana kuwa na haja ya kubadili mara kwa
         mara. Mabadiliko yoyote yatachapishwa kwa tovuti yetu haraka iwezekanavyo.
     </string>
+    <string name="tree_title">Miti</string>
+    <string name="fragment_data_uploaded_label">Imepakiwa</string>
+    <string name="fragment_data_waiting_to_upload_label">"Inasubiri Upakiaji "</string>
+    <string name="fragment_data_validated_label">Imethibitishwa</string>
+    <string name="payment_label">Malipo</string>
+    <string name="pending_label">Inasubiri</string>
+    <string name="total_paid_label">Jumla ya Imelipwa</string>
 
 </resources>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -55,4 +55,26 @@
     <dimen name="title_text_size">20sp</dimen>
     <dimen name="body_text_size">16sp</dimen>
     <dimen name="terms_text_body">12sp</dimen>
+
+    <!-- Dimensions used for Tree Data view(fragment_data.xml) -->
+    <dimen name="title_margin_start">16dp</dimen>
+    <dimen name="title_margin_top">16dp</dimen>
+    <dimen name="title_margin_end">16dp</dimen>
+
+    <dimen name="card_view_margin_start">16dp</dimen>
+    <dimen name="card_view_margin_top">16dp</dimen>
+    <dimen name="card_view_margin_end">16dp</dimen>
+    <dimen name="card_view_elevation">10dp</dimen>
+    <dimen name="card_view_corner_radius">20dp</dimen>
+
+    <dimen name="data_text_layout_height">40dp</dimen>
+    <dimen name="data_text_layout_width">0dp</dimen>
+    <dimen name="data_text_margin_start">5dp</dimen>
+    <dimen name="data_text_margin_top">16dp</dimen>
+    <dimen name="data_text_size">17sp</dimen>
+
+    <dimen name="button_elevation">20dp</dimen>
+    <dimen name="button_margin">307dp</dimen>
+    <dimen name="button_margin_bottom">16dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,4 +290,11 @@ Privacy Policy
     </string>
     <string name="syncing" translatable="false">Syncing...</string>
     <string name="uploading_trees" translatable="false">Uploading trees</string>
+    <string name="tree_title">Trees</string>
+    <string name="fragment_data_uploaded_label">Uploaded</string>
+    <string name="fragment_data_waiting_to_upload_label">Waiting to Upload</string>
+    <string name="fragment_data_validated_label">Validated</string>
+    <string name="payment_label">Payments</string>
+    <string name="pending_label">Pending</string>
+    <string name="total_paid_label">Total Paid</string>
 </resources>


### PR DESCRIPTION
The following PR contains changes addressing the requirement specified
in
https://github.com/Greenstand/treetracker-android/issues/416

- Upload, validated tree counts and payment data are modified to show
information from greenstand servers instead of local db values
- Waiting to upload tree count is obtained from the local db
- A new table to store the server  returned account data (upload,
validated, payment data) is created with planterInfoId as its primary
key

Note: Currently Uploaded, validated counts and payment data returns zero
as the value since the integration with the API is not yet done.

Tests:

Uploading to cloud
- Login to the app and add new trees
- Go to tree data and on clicking upload to cloud button, the number of
trees to upload goes down to zero.

Canceling the upload process
- After capture and add new trees starting the upload process
- While the process is on going, click on the stop icon
- The tree count of pending to upload will not change