### PR TITLE
Adding a  new issue type to document tech debt issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,0 +1,22 @@
+---
+name: Tech debt
+about: Create a report to help improve the code base.
+title: ''
+labels: 'tech debt'
+assignees: ''
+---
+
+**Describe the tech debt**
+A clear and concise description of what the tech debt is.
+
+**Impact of the tech debt**
+A description of the impact this technical debt has on the application (e.g. performance, 
+maintenance challenges) and its severity.
+
+**Urgency**
+How important it is to address it now versus later? If later should we even raise this ticket.
+
+**Intentional versus accidental**
+Is this introduced deliberately based on a trade-off to achieve a goal or shipping a feature?
+If so, what was the decision made on when this debt is scheduled to be addressed. 
+Please link the original issue that caused this intentional debt for context.


### PR DESCRIPTION
A new issue type in github to document tech debts that are intentionally or accidentally introduced to manage their priority and work.