### PR TITLE
Add ktlint formatting as git prehook on commit.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,8 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'io.fabric'
 apply plugin: 'com.github.triplet.play'
 apply plugin: "androidx.navigation.safeargs.kotlin"
-
+apply plugin: "org.jlleitschuh.gradle.ktlint"
+apply plugin: "org.jlleitschuh.gradle.ktlint-idea"
 
 def loadExtraProperties(String fileName) {
     def props = new Properties()
@@ -198,7 +199,7 @@ repositories {
 dependencies {
     implementation 'com.google.android.material:material:1.1.0-alpha05'
     implementation 'com.google.android.gms:play-services-maps:16.1.0'
-    compile 'com.google.maps.android:android-maps-utils:0.5+'
+    implementation 'com.google.maps.android:android-maps-utils:0.5+'
 
     //implementation 'com.amazonaws:aws-java-sdk:1.11.584'
     // 2.0: https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/setup-project-gradle.html
@@ -270,3 +271,15 @@ play {
 
 apply plugin: 'com.google.gms.google-services'
 
+ktlint {
+    android.set(true)
+    outputColorName.set("RED")
+}
+
+afterEvaluate {
+    // ktlint git precommit hook is insalled to .git folder in project root when running app in
+    // Intellij by the developer or when triggering gradle build. This ensures ktlint format is
+    // executed before code is committed.
+    tasks["preBuild"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
+    tasks["clean"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/data/NewTree.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/data/NewTree.kt
@@ -4,6 +4,8 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class NewTree(val photoPath: String,
-                   val content: String,
-                   val planterCheckInId: Long) : Parcelable
+data class NewTree(
+    val photoPath: String,
+    val content: String,
+    val planterCheckInId: Long
+) : Parcelable

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,16 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
+
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.google.gms:google-services:4.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:1.0.0"
+        classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -37,11 +40,10 @@ allprojects {
         treetracker_client_secret = "configure in treetracker.keys.properties"
 
     }
-
 }
+
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-
-


### PR DESCRIPTION
Adding ktlint as part of the gradle build and commit process to enable automated formatting where possible. Ktlint automates formatting of codebase to confirm to Kotlin communities style guide. Let me know if you have questions.

This addition will trigger incremental formatting as we touch existing files or adding new ones and hence won't format the whole project in one go.