### PR TITLE
Disregard automatic sign out when adding a tree in justdigit version

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
         android:name=".application.TreeTrackerApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
         android:name=".application.TreeTrackerApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/MapsFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/MapsFragment.kt
@@ -164,7 +164,8 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
                         ValueHelper.TIME_OF_LAST_PLANTER_CHECK_IN_SECONDS,
                         0
                     )
-                    if (currentTimestamp - lastTimeStamp > ValueHelper.CHECK_IN_TIMEOUT) {
+                    if (FeatureFlags.AUTOMATIC_SIGN_OUT_FEATURE_ENABLED &&
+                        currentTimestamp - lastTimeStamp > ValueHelper.CHECK_IN_TIMEOUT) {
                         findNavController().navigate(
                             MapsFragmentDirections.actionGlobalLoginFlowGraph())
                     } else {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/ExpireCheckInStatusUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/ExpireCheckInStatusUseCase.kt
@@ -1,7 +1,6 @@
 package org.greenstand.android.TreeTracker.usecases
 
 import android.content.SharedPreferences
-import org.greenstand.android.TreeTracker.managers.FeatureFlags
 import org.greenstand.android.TreeTracker.utilities.ValueHelper
 
 class ExpireCheckInStatusUseCase constructor(
@@ -15,15 +14,5 @@ class ExpireCheckInStatusUseCase constructor(
             .putLong(ValueHelper.PLANTER_INFO_ID, -1)
             .putString(ValueHelper.PLANTER_PHOTO, null)
             .apply()
-    }
-
-    fun readyForAutomaticSignout(): Boolean {
-        val currentTimestamp = System.currentTimeMillis() / 1000
-        val timeStampForLastCheckIn = sharedPreferences.getLong(
-            ValueHelper.TIME_OF_LAST_PLANTER_CHECK_IN_SECONDS,
-            0
-        )
-        return (FeatureFlags.AUTOMATIC_SIGN_OUT_FEATURE_ENABLED &&
-                currentTimestamp - timeStampForLastCheckIn > ValueHelper.CHECK_IN_TIMEOUT)
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/ExpireCheckInStatusUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/ExpireCheckInStatusUseCase.kt
@@ -1,9 +1,12 @@
 package org.greenstand.android.TreeTracker.usecases
 
 import android.content.SharedPreferences
+import org.greenstand.android.TreeTracker.managers.FeatureFlags
 import org.greenstand.android.TreeTracker.utilities.ValueHelper
 
-class ExpireCheckInStatusUseCase constructor(private val sharedPreferences: SharedPreferences) : UseCase<Unit, Unit>() {
+class ExpireCheckInStatusUseCase constructor(
+    private val sharedPreferences: SharedPreferences
+) : UseCase<Unit, Unit>() {
 
     override suspend fun execute(params: Unit) {
         sharedPreferences.edit()
@@ -14,4 +17,13 @@ class ExpireCheckInStatusUseCase constructor(private val sharedPreferences: Shar
             .apply()
     }
 
+    fun readyForAutomaticSignout(): Boolean {
+        val currentTimestamp = System.currentTimeMillis() / 1000
+        val timeStampForLastCheckIn = sharedPreferences.getLong(
+            ValueHelper.TIME_OF_LAST_PLANTER_CHECK_IN_SECONDS,
+            0
+        )
+        return (FeatureFlags.AUTOMATIC_SIGN_OUT_FEATURE_ENABLED &&
+                currentTimestamp - timeStampForLastCheckIn > ValueHelper.CHECK_IN_TIMEOUT)
+    }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
@@ -11,11 +11,13 @@ import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesUseCase
 import org.greenstand.android.TreeTracker.usecases.ExpireCheckInStatusUseCase
 import org.greenstand.android.TreeTracker.usecases.ValidateCheckInStatusUseCase
 
-class MapViewModel constructor(private val validateCheckInStatusUseCase: ValidateCheckInStatusUseCase,
-                               private val expireCheckInStatusUseCase: ExpireCheckInStatusUseCase,
-                               private val createFakeTreesUseCase: CreateFakeTreesUseCase,
-                               userLocationManager: UserLocationManager,
-                               private val userManager: UserManager) : ViewModel() {
+class MapViewModel constructor(
+    private val validateCheckInStatusUseCase: ValidateCheckInStatusUseCase,
+    private val expireCheckInStatusUseCase: ExpireCheckInStatusUseCase,
+    private val createFakeTreesUseCase: CreateFakeTreesUseCase,
+    userLocationManager: UserLocationManager,
+    private val userManager: UserManager
+) : ViewModel() {
 
     val checkInStatusLiveData = MutableLiveData<Boolean>()
     val locationUpdates: LiveData<Location?> = userLocationManager.locationUpdateLiveDate
@@ -33,6 +35,10 @@ class MapViewModel constructor(private val validateCheckInStatusUseCase: Validat
         }
     }
 
+    suspend fun requiresLogin(): Boolean {
+        return !validateCheckInStatusUseCase.execute(Unit)
+    }
+
     fun getPlanterName(): String {
         return userManager.firstName + " " + userManager.lastName
     }
@@ -41,5 +47,4 @@ class MapViewModel constructor(private val validateCheckInStatusUseCase: Validat
         createFakeTreesUseCase.execute(CreateFakeTreesParams(500))
         return true
     }
-
 }


### PR DESCRIPTION
The justdigit version of treetracker requires automatic sign out to not occur. Currently the default version has a background job that signs out the user if the last check in is two weeks old. But there is also another check in feature when the user is attempting to add a tree. This check makes check-in older than 2 hours requiring a login again. 

The solution is add the automatic sign-out feature flag to this condition thereby just-digit versions don't require this check while adding a tree.