### PR TITLE
Stop location update listener conditionally

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserLocationManager.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserLocationManager.kt
@@ -18,7 +18,7 @@ class UserLocationManager(
 ) {
 
     private val locationUpdates = MutableLiveData<Location?>()
-    val locationUpdateLiveDate: LiveData<Location?> = locationUpdates
+    val locationUpdateLiveData: LiveData<Location?> = locationUpdates
 
     var isUpdating: Boolean = false
         private set
@@ -71,7 +71,7 @@ class UserLocationManager(
 
     fun stopLocationUpdates() {
         Timber.d("Request to stop location updates submitted")
-        if (locationUpdateLiveDate.hasObservers())
+        if (locationUpdateLiveData.hasObservers())
             return
         Timber.d("Request to stop location update honored")
         locationManager.removeUpdates(locationUpdateListener)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserLocationManager.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserLocationManager.kt
@@ -90,14 +90,17 @@ class UserLocationManager(
     }
 
     private fun hasLocationPermissions(): Boolean {
-        return ContextCompat.checkSelfPermission(
-                    context,
-                    android.Manifest.permission.ACCESS_FINE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED ||
-                ContextCompat.checkSelfPermission(
-                    context,
-                    android.Manifest.permission.ACCESS_COARSE_LOCATION
-                ) == PackageManager.PERMISSION_GRANTED
+
+        val fineLocationPermission = ContextCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.ACCESS_FINE_LOCATION
+        )
+        val coarseLocationPermission = ContextCompat.checkSelfPermission(
+            context,
+            android.Manifest.permission.ACCESS_COARSE_LOCATION
+        )
+        return (fineLocationPermission == PackageManager.PERMISSION_GRANTED ||
+                coarseLocationPermission == PackageManager.PERMISSION_GRANTED)
     }
 }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserLocationManager.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/managers/UserLocationManager.kt
@@ -10,13 +10,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.greenstand.android.TreeTracker.utilities.ValueHelper
-import kotlinx.coroutines.channels.BroadcastChannel
-import kotlinx.coroutines.channels.ReceiveChannel
 import timber.log.Timber
 
-class UserLocationManager(private val locationManager: LocationManager,
-                          private val context: Context) {
-
+class UserLocationManager(
+    private val locationManager: LocationManager,
+    private val context: Context
+) {
 
     private val locationUpdates = MutableLiveData<Location?>()
     val locationUpdateLiveDate: LiveData<Location?> = locationUpdates
@@ -31,7 +30,7 @@ class UserLocationManager(private val locationManager: LocationManager,
         locationUpdates.postValue(null)
     }
 
-    private val locationUpdateListener = object : android.location.LocationListener  {
+    private val locationUpdateListener = object : android.location.LocationListener {
 
         @UseExperimental(ExperimentalCoroutinesApi::class)
         override fun onLocationChanged(location: Location) {
@@ -55,7 +54,12 @@ class UserLocationManager(private val locationManager: LocationManager,
     fun startLocationUpdates(): Boolean {
         return if (hasLocationPermissions()) {
             if (!isUpdating) {
-                locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0f, locationUpdateListener)
+                locationManager.requestLocationUpdates(
+                    LocationManager.GPS_PROVIDER,
+                    0,
+                    0f,
+                    locationUpdateListener
+                )
                 isUpdating = true
             }
             true
@@ -66,6 +70,10 @@ class UserLocationManager(private val locationManager: LocationManager,
     }
 
     fun stopLocationUpdates() {
+        Timber.d("Request to stop location updates submitted")
+        if (locationUpdateLiveDate.hasObservers())
+            return
+        Timber.d("Request to stop location update honored")
         locationManager.removeUpdates(locationUpdateListener)
         locationUpdates.postValue(null)
         isUpdating = false
@@ -81,13 +89,16 @@ class UserLocationManager(private val locationManager: LocationManager,
         } ?: false
     }
 
-    private fun hasLocationPermissions() : Boolean {
-        return ContextCompat.checkSelfPermission(context,
-                                                 android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
-                || ContextCompat.checkSelfPermission(context,
-                                                     android.Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+    private fun hasLocationPermissions(): Boolean {
+        return ContextCompat.checkSelfPermission(
+                    context,
+                    android.Manifest.permission.ACCESS_FINE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    context,
+                    android.Manifest.permission.ACCESS_COARSE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED
     }
-
 }
 
 enum class Accuracy {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CaptureTreeLocationUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CaptureTreeLocationUseCase.kt
@@ -4,7 +4,9 @@ import android.location.Location
 import android.util.Base64
 import androidx.lifecycle.Observer
 import com.google.gson.Gson
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.database.entity.LocationDataEntity
 import org.greenstand.android.TreeTracker.managers.UserLocationManager
@@ -21,7 +23,7 @@ class CaptureTreeLocationUseCase(
     private val locationObserver: Observer<Location?> = Observer {
         it?.apply {
             MainScope().launch(Dispatchers.IO) {
-                userManager.planterCheckinId?.let{ planterCheckinId ->
+                userManager.planterCheckinId?.let { planterCheckinId ->
                     val locationData =
                         LocationData(
                             planterCheckinId,
@@ -42,11 +44,11 @@ class CaptureTreeLocationUseCase(
     }
 
     fun startLocationCapture() {
-        userLocationManager.locationUpdateLiveDate.observeForever(locationObserver)
+        userLocationManager.locationUpdateLiveData.observeForever(locationObserver)
     }
 
     fun stopLocationCapture() {
-        userLocationManager.locationUpdateLiveDate.removeObserver(locationObserver)
+        userLocationManager.locationUpdateLiveData.removeObserver(locationObserver)
     }
 }
 
@@ -57,4 +59,3 @@ data class LocationData(
     val accuracy: Float,
     val capturedAt: Long
 )
-


### PR DESCRIPTION
`UserLocationManager` removes the `LocationUpdateListener`  when the Main activity goes out of scope. This causes the location data collection to not occur when capturing a tree using the ImageCaptureActivity. The location data stream is stopped and hence no updates are posted to the `locationUpdateLiveData` which `CaptureTreeLocationUseCase` depends on.

 The fix/change addresses this by checking if there is an observer for the LocationUpdateLiveData and only when absent to remove the `LocationUpdateListener` from the android's `LocationManager` thereby allowing the location stream to happen when entering `ImageCaptureActivity` by leaving `MainActivity`.

