### PR TITLE
Bring migration script up-to date in master

### DIFF
--- a/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/6.json
+++ b/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/6.json
@@ -1,0 +1,422 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "238caf84a0eb4bedccdeb189bf9f7a17",
+    "entities": [
+      {
+        "tableName": "planter_check_in",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planter_info_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`planter_info_id`) REFERENCES `planter_info`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planterInfoId",
+            "columnName": "planter_info_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_planter_check_in_planter_info_id",
+            "unique": false,
+            "columnNames": [
+              "planter_info_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_check_in_planter_info_id` ON `${TABLE_NAME}` (`planter_info_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "planter_info",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_info_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "planter_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planter_identifier` TEXT NOT NULL, `first_name` TEXT NOT NULL, `last_name` TEXT NOT NULL, `organization` TEXT, `phone` TEXT, `email` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, `record_uuid` TEXT NOT NULL DEFAULT '')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "planter_identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recordUuid",
+            "columnName": "record_uuid",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_planter_info_planter_identifier",
+            "unique": false,
+            "columnNames": [
+              "planter_identifier"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_info_planter_identifier` ON `${TABLE_NAME}` (`planter_identifier`)"
+          },
+          {
+            "name": "index_planter_info_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_info_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tree_attribute",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `tree_capture_id` INTEGER NOT NULL, FOREIGN KEY(`tree_capture_id`) REFERENCES `tree_capture`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeCaptureId",
+            "columnName": "tree_capture_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_attribute_tree_capture_id",
+            "unique": false,
+            "columnNames": [
+              "tree_capture_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_attribute_tree_capture_id` ON `${TABLE_NAME}` (`tree_capture_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tree_capture",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tree_capture_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tree_capture",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uuid` TEXT NOT NULL, `planter_checkin_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `note_content` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `accuracy` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, FOREIGN KEY(`planter_checkin_id`) REFERENCES `planter_check_in`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planterCheckInId",
+            "columnName": "planter_checkin_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noteContent",
+            "columnName": "note_content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_capture_planter_checkin_id",
+            "unique": false,
+            "columnNames": [
+              "planter_checkin_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_planter_checkin_id` ON `${TABLE_NAME}` (`planter_checkin_id`)"
+          },
+          {
+            "name": "index_tree_capture_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "planter_check_in",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_checkin_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "location_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `base64_json` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationDataJson",
+            "columnName": "base64_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_location_data_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_data_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '238caf84a0eb4bedccdeb189bf9f7a17')"
+    ]
+  }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
-import org.greenstand.android.TreeTracker.database.entity.*
+import org.greenstand.android.TreeTracker.database.entity.LocationDataEntity
+import org.greenstand.android.TreeTracker.database.entity.PlanterCheckInEntity
+import org.greenstand.android.TreeTracker.database.entity.PlanterInfoEntity
+import org.greenstand.android.TreeTracker.database.entity.TreeAttributeEntity
+import org.greenstand.android.TreeTracker.database.entity.TreeCaptureEntity
 
 @Database(
     entities = [
@@ -14,7 +18,7 @@ import org.greenstand.android.TreeTracker.database.entity.*
         TreeCaptureEntity::class,
         LocationDataEntity::class
     ],
-    version = 4,
+    version = 6,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -33,9 +37,9 @@ abstract class AppDatabase : RoomDatabase() {
                                                     DB_NAME
                     )
                         .addMigrations(
-                            MIGRATION_1_2,
-                            MIGRATION_2_3,
-                            MIGRATION_3_4
+                            MIGRATION_3_4,
+                            MIGRATION_4_5,
+                            MIGRATION_5_6
                         )
                         .build()
                 }
@@ -43,8 +47,6 @@ abstract class AppDatabase : RoomDatabase() {
             return INSTANCE!!
         }
 
-        private const val DB_NAME = "treetracker.v1.db"
+        private const val DB_NAME = "treetracker.v2.db"
     }
-
 }
-

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/Migrations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/Migrations.kt
@@ -4,66 +4,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.greenstand.android.TreeTracker.database.entity.PlanterInfoEntity
 
-
-val MIGRATION_1_2 = object : Migration(1, 2) {
-
-    override fun migrate(database: SupportSQLiteDatabase) {
-        try {
-            database.beginTransaction()
-            val createTableVersionNew = """
-                |CREATE TABLE `planter_check_in_new` (
-                |   `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                |   `planter_info_id` INTEGER NOT NULL,
-                |   `local_photo_path` TEXT,
-                |   `photo_url` TEXT,
-                |   `latitude` REAL NOT NULL,
-                |   `longitude` REAL NOT NULL,
-                |   `created_at` INTEGER NOT NULL,
-                |    FOREIGN KEY (`planter_info_id`) REFERENCES `planter_info`(`_id`) 
-                |    ON UPDATE CASCADE ON DELETE NO ACTION )
-                |    """.trimMargin()
-            database.execSQL(createTableVersionNew)
-
-            val populateNewTable = """INSERT INTO `planter_check_in_new` (
-                |   `_id`, `planter_info_id`, `local_photo_path`, `photo_url`, 
-                |   `latitude`, `longitude`, `created_at`
-                | )  SELECT `_id`, `planter_info_id`, `local_photo_path`, `photo_url`, 
-                |   `latitude`, `longitude`, `created_at` FROM `planter_check_in`
-            """.trimMargin()
-            database.execSQL(populateNewTable)
-
-            // Drop the original table
-            database.execSQL("DROP TABLE `planter_check_in`")
-
-            // Rename the new table to be same as the original table
-            database.execSQL("ALTER TABLE `planter_check_in_new` RENAME TO `planter_check_in`")
-
-            // Recreate indexes
-            val indexCreation = """
-                |  CREATE INDEX `index_planter_check_in_planter_info_id` ON 
-                |  `planter_check_in` (`planter_info_id`)
-                |  """.trimMargin()
-            database.execSQL(indexCreation)
-
-            // Add a new column to `planter_info`
-            database.execSQL("ALTER TABLE `planter_info` ADD COLUMN `bundle_id` TEXT")
-
-            if (database.isDatabaseIntegrityOk) {
-                database.setTransactionSuccessful()
-            }
-        } finally {
-            database.endTransaction()
-        }
-    }
-}
-
-val MIGRATION_2_3 = object : Migration(2, 3) {
-    override fun migrate(database: SupportSQLiteDatabase) {
-        database.execSQL("ALTER TABLE ${PlanterInfoEntity.TABLE} ADD COLUMN ${PlanterInfoEntity.RECORD_UUID} TEXT NOT NULL DEFAULT ''")
-    }
-}
-
-val MIGRATION_3_4 = object : Migration(3, 4) {
+val MIGRATION_5_6 = object : Migration(5, 6) {
 
     override fun migrate(database: SupportSQLiteDatabase) {
         try {
@@ -86,3 +27,194 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
     }
 }
 
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        val sql = """ALTER TABLE ${PlanterInfoEntity.TABLE}
+            | ADD COLUMN ${PlanterInfoEntity.RECORD_UUID} TEXT NOT NULL DEFAULT ''
+            | """.trimMargin()
+        database.execSQL(sql)
+    }
+}
+
+val MIGRATION_3_4 = object : Migration(3, 4) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+
+        try {
+            database.beginTransaction()
+
+            // Create version 4 entities (tables)
+            val createPlanterInfo = """CREATE TABLE IF NOT EXISTS `planter_info` (
+                | `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                | `planter_identifier` TEXT NOT NULL,
+                | `first_name` TEXT NOT NULL,
+                | `last_name` TEXT NOT NULL,
+                | `organization` TEXT,
+                |  `phone` TEXT,
+                |  `email` TEXT,
+                |  `latitude` REAL NOT NULL,
+                |  `longitude` REAL NOT NULL,
+                |  `uploaded` INTEGER NOT NULL,
+                |  `created_at` INTEGER NOT NULL,
+                |  `bundle_id` TEXT
+                |  )""".trimMargin()
+            database.execSQL(createPlanterInfo)
+            val createIndexPlanterIdentifier = """
+                | CREATE INDEX IF NOT EXISTS 
+                | `index_planter_identifier` ON `planter_info` (`planter_identifier`)
+                | """.trimMargin()
+            database.execSQL(createIndexPlanterIdentifier)
+            val createIndexUploaded = """
+                | CREATE INDEX IF NOT EXISTS `index_planter_uploaded`
+                | ON `planter_info` (`uploaded`)
+                | """.trimMargin()
+            database.execSQL(createIndexUploaded)
+
+            val createPlanterCheckIn = """CREATE TABLE IF NOT EXISTS `planter_check_in` (
+                | `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                | `planter_info_id` INTEGER NOT NULL,
+                | `local_photo_path` TEXT,
+                | `photo_url` TEXT,
+                | `latitude` REAL NOT NULL,
+                | `longitude` REAL NOT NULL,
+                | `created_at` INTEGER NOT NULL,
+                | FOREIGN KEY(`planter_info_id`) REFERENCES `planter_info`(`_id`)
+                | ON UPDATE CASCADE ON DELETE NO ACTION
+                | )""".trimMargin()
+            database.execSQL(createPlanterCheckIn)
+
+            val createIndexPlanterInfo = """CREATE INDEX IF NOT EXISTS
+                |`index_planter_check_in_planter_info_id`
+                | ON `planter_check_in` (`planter_info_id`)""".trimMargin()
+            database.execSQL(createIndexPlanterInfo)
+
+            val createTreeCapture = """CREATE TABLE IF NOT EXISTS `tree_capture` (
+                | `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                | `uuid` TEXT NOT NULL,
+                | `planter_checkin_id` INTEGER NOT NULL,
+                | `local_photo_path` TEXT,
+                | `photo_url` TEXT,
+                | `note_content` TEXT NOT NULL,
+                | `latitude` REAL NOT NULL,
+                | `longitude` REAL NOT NULL,
+                | `accuracy` REAL NOT NULL,
+                | `uploaded` INTEGER NOT NULL,
+                | `created_at` INTEGER NOT NULL,
+                | `bundle_id` TEXT,
+                | FOREIGN KEY(`planter_checkin_id`) 
+                | REFERENCES `planter_check_in`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )
+                | """.trimMargin()
+            database.execSQL(createTreeCapture)
+
+            val createPlanterCheckInIndex = """CREATE INDEX IF NOT EXISTS
+                | `index_tree_capture_planter_checkin_id` ON `tree_capture` (`planter_checkin_id`)
+                | """.trimMargin()
+            database.execSQL(createPlanterCheckInIndex)
+
+            val createPlanterCheckInUploadIndex = """CREATE INDEX IF NOT EXISTS
+                | `index_tree_capture_uploaded` ON `tree_capture` (`uploaded`)
+                | """.trimMargin()
+            database.execSQL(createPlanterCheckInUploadIndex)
+
+            val createTreeAttribute = """CREATE TABLE IF NOT EXISTS `tree_attribute` (
+                | `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                | `key` TEXT NOT NULL, `value` TEXT NOT NULL,
+                | `tree_capture_id` INTEGER NOT NULL,
+                | FOREIGN KEY(`tree_capture_id`) REFERENCES `tree_capture`(`_id`)
+                | ON UPDATE CASCADE ON DELETE NO ACTION )
+                | """.trimMargin()
+            database.execSQL(createTreeAttribute)
+
+            val createIndexTreeCapture = """CREATE INDEX IF NOT EXISTS 
+                |`index_tree_attribute_tree_capture_id` 
+                | ON `tree_attribute` (`tree_capture_id`)
+                | """.trimMargin()
+            database.execSQL(createIndexTreeCapture)
+
+            // Populate Planter registrations
+            val populatePlanterInfoEntity = """INSERT INTO `planter_info` (
+                | `_id`, `planter_identifier`, `first_name`, `last_name`, `organization`,
+                | `phone`, `email`, `latitude`, `longitude`, `uploaded`, `created_at`)
+                | SELECT `_id`, `identifier`, `first_name`, `last_name`, `organization`,
+                | `phone`, `email`, substr(`location`, 0, instr(`location`, ',')), 
+                |  substr(`location`, instr(`location`, ',')+1), `uploaded`, 
+                |  strftime('%s', `time_created`) FROM `planter_details`
+                | """.trimMargin()
+            database.execSQL(populatePlanterInfoEntity)
+
+            // Populate planter checkins
+            val populatePlanterCheckIns = """INSERT INTO `planter_check_in` (
+            | `_id`, `planter_info_id`, `local_photo_path`, `photo_url`,
+            | `latitude`, `longitude`, `created_at`) SELECT `_id`, `planter_details_id`,
+            | `photo_path`, `photo_url`, substr(`location`, 0, instr(`location`, ',')),
+            | substr(`location`, instr(`location`, ',')+1), `time_created`
+            | FROM `planter_identifications`
+            | """.trimMargin()
+            database.execSQL(populatePlanterCheckIns)
+
+            // Populate tree captures
+            val populateTreeCaptures = """INSERT INTO `tree_capture` (`_id`, `uuid`,
+            | `planter_checkin_id`, `local_photo_path`, `note_content`,
+            | `latitude`, `longitude`, `accuracy`, `uploaded`, `created_at`) SELECT
+            | `tree`.`_id`, `tree`.`uuid`, `tree`.`planter_identification_id`, `photo`.`name`,
+            | `note`.`content`, `location`.`lat`, `location`.`long`,
+            | `location`.`accuracy`, `tree`.`is_synced`, strftime('%s', `tree`.`time_created`)
+            | FROM `tree`
+            | LEFT OUTER JOIN `location` ON `location`.`_id` = `tree`.`location_id`
+            | LEFT OUTER JOIN `tree_photo` ON `tree`.`_id` = `tree_photo`.`tree_id`
+            | LEFT OUTER JOIN `photo` ON `photo`.`_id` = `tree_photo`.`photo_id`
+            | LEFT OUTER JOIN `tree_note` ON `tree`.`_id` = `tree_note`.`tree_id`
+            | LEFT OUTER JOIN `note` ON `note`.`_id` = `tree_note`.`note_id`
+            | LEFT OUTER JOIN `planter_identifications`
+            | ON `planter_identifications`.`_id` = `tree`.`planter_identification_id`
+            | """.trimMargin()
+            database.execSQL(populateTreeCaptures)
+
+            val populateTreeAttributes = """INSERT INTO `tree_attribute` (
+            | `_id`, `key`, `value`, `tree_capture_id`) SELECT `_id`, `key`, `value`, `tree_id`
+            | FROM `tree_attributes`
+            | """.trimMargin()
+            database.execSQL(populateTreeAttributes)
+
+            // Drop tables found in 1.2.7 release branch
+            val deletePendingUpdates = "drop table if exists `pending_updates`"
+            database.execSQL(deletePendingUpdates)
+
+            val dropTreeAttributes = "drop table if exists `tree_attributes`"
+            database.execSQL(dropTreeAttributes)
+
+            val dropTreePhoto = "drop table if exists `tree_photo`"
+            database.execSQL(dropTreePhoto)
+
+            val dropNoteEntity = "drop table if exists `tree_note`"
+            database.execSQL(dropNoteEntity)
+
+            val dropTree = "drop table if exists `tree`"
+            database.execSQL(dropTree)
+
+            val dropSettings = "drop table if exists `settings`"
+            database.execSQL(dropSettings)
+
+            val dropPlanterIdentifications = "drop table if exists `planter_identifications`"
+            database.execSQL(dropPlanterIdentifications)
+
+            val dropPlanterDetails = "drop table if exists `planter_details`"
+            database.execSQL(dropPlanterDetails)
+
+            val dropPhoto = "drop table if exists `photo`"
+            database.execSQL(dropPhoto)
+
+            val dropNote = "drop table if exists `note`"
+            database.execSQL(dropNote)
+
+            val dropLocation = "drop table if exists `location`"
+            database.execSQL(dropLocation)
+
+            if (database.isDatabaseIntegrityOk) {
+                database.setTransactionSuccessful()
+            }
+        } finally {
+            database.endTransaction()
+        }
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
@@ -1,13 +1,23 @@
 package org.greenstand.android.TreeTracker.database
 
-import androidx.room.*
-import org.greenstand.android.TreeTracker.database.entity.*
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+import org.greenstand.android.TreeTracker.database.entity.LocationDataEntity
+import org.greenstand.android.TreeTracker.database.entity.PlanterCheckInEntity
+import org.greenstand.android.TreeTracker.database.entity.PlanterInfoEntity
+import org.greenstand.android.TreeTracker.database.entity.TreeAttributeEntity
+import org.greenstand.android.TreeTracker.database.entity.TreeCaptureEntity
 import org.greenstand.android.TreeTracker.database.views.TreeMapMarkerDbView
 
 @Dao
 interface TreeTrackerDAO {
 
-    @Query("SELECT _id FROM planter_info WHERE planterInfoId = :identifier")
+    @Query("SELECT _id FROM planter_info WHERE planter_identifier = :identifier")
     fun getPlanterInfoIdByIdentifier(identifier: String): Long?
 
     @Query("SELECT * FROM planter_info")
@@ -34,10 +44,10 @@ interface TreeTrackerDAO {
     @Query("UPDATE planter_info SET uploaded = :isUploaded WHERE _id IN (:ids)")
     fun updatePlanterInfoUploadStatus(ids: List<Long>, isUploaded: Boolean)
 
-
     @Transaction
-    @Query("SELECT * FROM planter_check_in WHERE photo_url IS null AND planter_info_id = :planterInfoId")
+    @Query("SELECT * FROM planter_check_in WHERE photo_url IS null AND planter_info_id = :planterInfoId") // kt-lint-disable max-line-length
     fun getPlanterCheckInsToUpload(planterInfoId: Long): List<PlanterCheckInEntity>
+    // kt-lint-enable max-line-length
 
     @Transaction
     @Query("SELECT * FROM planter_check_in WHERE _id IN (:planterCheckInIds)")
@@ -60,8 +70,6 @@ interface TreeTrackerDAO {
 
     @Query("UPDATE planter_check_in SET local_photo_path = null WHERE _id IN (:ids)")
     fun removePlanterCheckInLocalImagePaths(ids: List<Long>)
-
-
 
     @Query("SELECT latitude, longitude, _id as treeCaptureId FROM tree_capture")
     fun getTreeDataForMap(): List<TreeMapMarkerDbView>
@@ -113,7 +121,6 @@ interface TreeTrackerDAO {
 
     @Delete
     fun deleteTreeCapture(treeCaptureEntity: TreeCaptureEntity)
-
 
     @Query("SELECT * FROM tree_attribute")
     fun getAllTreeAttributes(): List<TreeAttributeEntity>

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
@@ -47,7 +47,6 @@ interface TreeTrackerDAO {
     @Transaction
     @Query("SELECT * FROM planter_check_in WHERE photo_url IS null AND planter_info_id = :planterInfoId") // kt-lint-disable max-line-length
     fun getPlanterCheckInsToUpload(planterInfoId: Long): List<PlanterCheckInEntity>
-    // kt-lint-enable max-line-length
 
     @Transaction
     @Query("SELECT * FROM planter_check_in WHERE _id IN (:planterCheckInIds)")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/PlanterInfoEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/PlanterInfoEntity.kt
@@ -6,7 +6,7 @@ import androidx.room.PrimaryKey
 
 @Entity(tableName = PlanterInfoEntity.TABLE)
 data class PlanterInfoEntity(
-    @ColumnInfo(name = IDENTIFIER)
+    @ColumnInfo(name = IDENTIFIER, index = true)
     var identifier: String,
     @ColumnInfo(name = FIRST_NAME)
     var firstName: String,
@@ -22,7 +22,7 @@ data class PlanterInfoEntity(
     var latitude: Double,
     @ColumnInfo(name = LONGITUDE)
     var longitude: Double,
-    @ColumnInfo(name = UPLOADED)
+    @ColumnInfo(name = UPLOADED, index = true)
     var uploaded: Boolean = false,
     @ColumnInfo(name = CREATED_AT)
     var createdAt: Long,
@@ -40,7 +40,7 @@ data class PlanterInfoEntity(
         const val TABLE = "planter_info"
 
         const val ID = "_id"
-        const val IDENTIFIER = "planterInfoId"
+        const val IDENTIFIER = "planter_identifier"
         const val FIRST_NAME = "first_name"
         const val LAST_NAME = "last_name"
         const val ORGANIZATION = "organization"

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/TreeCaptureEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/TreeCaptureEntity.kt
@@ -33,7 +33,7 @@ data class TreeCaptureEntity(
     var longitude: Double,
     @ColumnInfo(name = ACCURACY)
     var accuracy: Double,
-    @ColumnInfo(name = UPLOADED)
+    @ColumnInfo(name = UPLOADED, index = true)
     var uploaded: Boolean = false,
     @ColumnInfo(name = CREATED_AT)
     var createAt: Long,


### PR DESCRIPTION
Migration script for upgrading 1.2.7 to 1.3 resulted in version number difference, db package name difference, migration script differences between the production version and what exists in master.

This PR merges the changes made for 1.3 release along with what has been added to master. This will keep the app db consistent with future releases while maintaining history.