### PR TITLE
Add convergence indicator to location data

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/MapsFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/MapsFragment.kt
@@ -30,12 +30,9 @@ import kotlinx.android.synthetic.main.fragment_map.goToUploadsButton
 import kotlinx.android.synthetic.main.fragment_map.mapUserImage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.map.TreeMapMarker
@@ -45,7 +42,6 @@ import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.User
 import org.greenstand.android.TreeTracker.models.accuracyStatus
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
-import org.greenstand.android.TreeTracker.utilities.LocationDataConfig
 import org.greenstand.android.TreeTracker.utilities.TreeClusterRenderer
 import org.greenstand.android.TreeTracker.utilities.vibrate
 import org.greenstand.android.TreeTracker.viewmodels.MapViewModel
@@ -170,18 +166,9 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
                             findNavController().navigate(
                                 MapsFragmentDirections.actionGlobalLoginFlowGraph())
                         } else {
-                            convergenceProgressView.visibility = View.VISIBLE
                             vm.turnOnTreeCaptureMode()
-                            try {
-                                withTimeout(LocationDataConfig.CONVERGENCE_TIMEOUT) {
-                                    while (!vm.isConvergenceWithinRange()) {
-                                        delay(LocationDataConfig.MIN_TIME_BTWN_UPDATES)
-                                    }
-                                }
-                            } catch (e: TimeoutCancellationException) {
-                                Timber.d("Convergence request timed out")
-                                vm.convergenceRequestTimedout()
-                            }
+                            convergenceProgressView.visibility = View.VISIBLE
+                            vm.resolveLocationConvergence()
                             convergenceProgressView.visibility = View.GONE
                             findNavController()
                                 .navigate(MapsFragmentDirections.actionMapsFragmentToNewTreeGraph())

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
@@ -142,33 +142,17 @@ class LocationDataCapturer(
     private val locationUpdateManager: LocationUpdateManager,
     private val treeTrackerDAO: TreeTrackerDAO
 ) {
-    var convergenceWithinRange: Boolean = false
-
     private val gson = GsonBuilder().serializeNulls().create()
     private var locationsDeque: Deque<Location> = LinkedList<Location>()
     var generatedTreeUuid: UUID? = null
         private set
-    var convergence: Convergence? = null
+    private var convergence: Convergence? = null
+    private var convergenceStatus: ConvergenceStatus? = null
 
     private val locationObserver: Observer<Location?> = Observer { location ->
         location?.apply {
 
-            MainScope().launch(Dispatchers.IO) {
-                val locationData =
-                    LocationData(
-                        userManager.planterCheckinId,
-                        latitude,
-                        longitude,
-                        accuracy,
-                        generatedTreeUuid?.toString(),
-                        System.currentTimeMillis()
-                    )
-                val jsonValue = gson.toJson(locationData)
-                Timber.d("Inserting new location data $jsonValue")
-                treeTrackerDAO.insertLocationData(LocationDataEntity(jsonValue))
-            }
-
-            if (isInTreeCaptureMode() && !convergenceWithinRange) {
+            if (isInTreeCaptureMode() && !isConvergenceWithinRange()) {
 
                 val evictedLocation: Location? = if (locationsDeque.size >= CONVERGENCE_DATA_SIZE)
                     locationsDeque.pollFirst() else null
@@ -197,10 +181,27 @@ class LocationDataCapturer(
                     val longStdDev = convergence?.longitudinalStandardDeviation()
                     val latStdDev = convergence?.latitudinalStandardDeviation()
                     if (longStdDev != null && latStdDev != null) {
-                        convergenceWithinRange = longStdDev < LONG_STD_DEV &&
-                                latStdDev < LAT_STD_DEV
+                        if (longStdDev < LONG_STD_DEV && latStdDev < LAT_STD_DEV) {
+                            convergenceStatus = ConvergenceStatus.CONVERGED
+                        }
                     }
                 }
+            }
+
+            MainScope().launch(Dispatchers.IO) {
+                val locationData =
+                    LocationData(
+                        userManager.planterCheckinId,
+                        latitude,
+                        longitude,
+                        accuracy,
+                        generatedTreeUuid?.toString(),
+                        convergenceStatus,
+                        System.currentTimeMillis()
+                    )
+                val jsonValue = gson.toJson(locationData)
+                Timber.d("Inserting new location data $jsonValue")
+                treeTrackerDAO.insertLocationData(LocationDataEntity(jsonValue))
             }
         }
     }
@@ -209,12 +210,24 @@ class LocationDataCapturer(
         locationUpdateManager.locationUpdateLiveData.observeForever(locationObserver)
     }
 
+    fun isConvergenceWithinRange(): Boolean = ConvergenceStatus.CONVERGED == convergenceStatus
+
+    /*
+     * When the caller (MapFragment via a ViewModel) waits for location convergence to
+     * occur and the waiting period exceeds the threshold configured, this method is called
+     * to mark the convergence status as timed out for location data pipeline analysis.
+     */
+    fun markConvergenceTimeout() {
+        convergenceStatus = ConvergenceStatus.TIMED_OUT
+    }
+
     fun isInTreeCaptureMode(): Boolean {
         return generatedTreeUuid != null
     }
 
     fun turnOnTreeCaptureMode() {
         generatedTreeUuid = UUID.randomUUID()
+        convergenceStatus = ConvergenceStatus.NOT_CONVERGED
         Timber.d("Convergence: Tree capture mode turned on")
     }
 
@@ -222,7 +235,7 @@ class LocationDataCapturer(
         generatedTreeUuid = null
         convergence = null
         locationsDeque.clear()
-        convergenceWithinRange = false
+        convergenceStatus = null
         Timber.d("Convergence: Tree capture turned off")
     }
 }
@@ -314,11 +327,14 @@ data class ConvergenceStats(
     val standardDeviation: Double
 )
 
+enum class ConvergenceStatus { CONVERGED, NOT_CONVERGED, TIMED_OUT }
+
 data class LocationData(
     val planterCheckInId: Long?,
     val latitude: Double,
     val longitude: Double,
     val accuracy: Float,
     val treeUuid: String?,
+    val convergenceStatus: ConvergenceStatus?,
     val capturedAt: Long
 )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
@@ -146,7 +146,8 @@ class LocationDataCapturer(
     private var locationsDeque: Deque<Location> = LinkedList<Location>()
     var generatedTreeUuid: UUID? = null
         private set
-    private var convergence: Convergence? = null
+    var convergence: Convergence? = null
+        private set
     private var convergenceStatus: ConvergenceStatus? = null
 
     private val locationObserver: Observer<Location?> = Observer { location ->

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
@@ -55,5 +55,7 @@ class MapViewModel constructor(
         stepCounter.enable()
     }
 
-    fun isConvergenceWithinRange() = locationDataCapturer.convergenceWithinRange
+    fun isConvergenceWithinRange() = locationDataCapturer.isConvergenceWithinRange()
+
+    fun convergenceRequestTimedout() = locationDataCapturer.markConvergenceTimeout()
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
@@ -4,6 +4,9 @@ import android.location.Location
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.StepCounter
@@ -11,6 +14,8 @@ import org.greenstand.android.TreeTracker.models.User
 import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesParams
 import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesUseCase
 import org.greenstand.android.TreeTracker.usecases.ValidateCheckInStatusUseCase
+import org.greenstand.android.TreeTracker.utilities.LocationDataConfig
+import timber.log.Timber
 
 class MapViewModel constructor(
     private val validateCheckInStatusUseCase: ValidateCheckInStatusUseCase,
@@ -50,12 +55,21 @@ class MapViewModel constructor(
         return true
     }
 
-    suspend fun turnOnTreeCaptureMode() {
+    fun turnOnTreeCaptureMode() {
         locationDataCapturer.turnOnTreeCaptureMode()
         stepCounter.enable()
     }
 
-    fun isConvergenceWithinRange() = locationDataCapturer.isConvergenceWithinRange()
-
-    fun convergenceRequestTimedout() = locationDataCapturer.markConvergenceTimeout()
+    suspend fun resolveLocationConvergence() {
+        try {
+            withTimeout(LocationDataConfig.CONVERGENCE_TIMEOUT) {
+                while (!locationDataCapturer.isConvergenceWithinRange()) {
+                    delay(LocationDataConfig.MIN_TIME_BTWN_UPDATES)
+                }
+            }
+        } catch (e: TimeoutCancellationException) {
+            Timber.d("Convergence request timed out")
+            locationDataCapturer.markConvergenceTimeout()
+        }
+    }
 }

--- a/app/src/test/java/org/greenstand/android/TreeTracker/models/LocationDataCapturerTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/models/LocationDataCapturerTest.kt
@@ -12,6 +12,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
+import org.greenstand.android.TreeTracker.preferences.Preferences
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -25,7 +26,7 @@ class LocationDataCapturerTest {
     private lateinit var locationDataCapturer: LocationDataCapturer
 
     @MockK(relaxed = true)
-    private lateinit var userManager: UserManager
+    private lateinit var user: User
     @MockK(relaxed = true)
     private lateinit var locationUpdateManager: LocationUpdateManager
     @MockK(relaxed = true)
@@ -39,9 +40,9 @@ class LocationDataCapturerTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        preferences = Preferences(sharedPreferences, userManager)
+        preferences = Preferences(sharedPreferences)
         locationDataCapturer = LocationDataCapturer(
-            userManager,
+            user,
             locationUpdateManager,
             treeTrackerDAO
         )
@@ -90,7 +91,7 @@ class LocationDataCapturerTest {
             locationsLiveData.postValue(location)
         }
 
-        assertFalse(locationDataCapturer.convergenceWithinRange)
+        assertFalse(locationDataCapturer.isConvergenceWithinRange())
     }
 
     val locationValuesLowVariance = listOf(
@@ -114,7 +115,7 @@ class LocationDataCapturerTest {
             every { location.latitude } returns locationValuesLowVariance[i].second
             locationsLiveData.postValue(location)
         }
-        assertTrue(locationDataCapturer.convergenceWithinRange)
+        assertTrue(locationDataCapturer.isConvergenceWithinRange())
     }
 
     // Hard coded longitude and latitude pair values
@@ -139,6 +140,6 @@ class LocationDataCapturerTest {
             locationsLiveData.postValue(location)
         }
 
-        assertFalse(locationDataCapturer.convergenceWithinRange)
+        assertFalse(locationDataCapturer.isConvergenceWithinRange())
     }
 }


### PR DESCRIPTION
The change is to add a field in location data to indicate whether the location collected during tree capture is converged or if the request for convergence is timed out.  Since location data is also collected outside the scope of tree capture, the convergence status in those cases will be null.
