### PR TITLE
Create a separate workflow for github pull request builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ name: Treetracker Android App CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,45 @@
+name: Treetracker Android App CI PR
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Generate dummy property file
+        run bash echo "#Treetracker API Keys
+        treetracker_client_id=dummy-id
+        treetracker_client_secret=dummy-secret
+        s3_dev_identity_pool_id=dummy-pool-id-dev
+        s3_test_identity_pool_id=dummy-pool-id-test" > treetracker.keys.properties
+      - name: Unit tests
+        run: bash ./gradlew test --stacktrace
+      - name: Delete dummy property file
+        run bash rm treetracker.keys.properties
+  build:
+    name: Generate APK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build Debug APK
+        run: bash ./gradlew :app:assembleDebug
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: App
+          path: ${{ github.workspace }}/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
-    name: Run unit tests
+  build:
+    name: test and assemble
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,22 +24,7 @@ jobs:
         s3_test_identity_pool_id=dummy-pool-id-test" > treetracker.keys.properties
       - name: Unit tests
         run: bash ./gradlew test --stacktrace
-      - name: Delete dummy property file
-        run bash rm treetracker.keys.properties
-  build:
-    name: Generate APK
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
       - name: Build Debug APK
         run: bash ./gradlew :app:assembleDebug
-
-      - name: Upload APK
-        uses: actions/upload-artifact@v2
-        with:
-          name: App
-          path: ${{ github.workspace }}/app/build/outputs/apk/debug/app-debug.apk
+      - name: Delete dummy property file
+        run bash rm treetracker.keys.properties


### PR DESCRIPTION
This PR is to test a separate build process for pull requests from merge builds.  The dependency on property file causes the current version of the workflow to fail on PR builds. The change here to temporarily creating a dummy property file to allow the PR builds to succeed.
