### PR TITLE
Capture device orientation by using rotation vector sensor

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
@@ -9,20 +9,27 @@ import android.view.TextureView
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.camera.core.*
+import androidx.camera.core.CameraX
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureConfig
+import androidx.camera.core.Preview
+import androidx.camera.core.PreviewConfig
+import java.io.File
 import org.greenstand.android.TreeTracker.R
+import org.greenstand.android.TreeTracker.models.DeviceOrientation
 import org.greenstand.android.TreeTracker.utilities.AutoFitPreviewBuilder
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
 import org.greenstand.android.TreeTracker.utilities.ValueHelper
 import org.greenstand.android.TreeTracker.viewmodels.NewTreeViewModel.Companion.FOCUS_THRESHOLD
+import org.koin.android.ext.android.inject
 import timber.log.Timber
-import java.io.File
 
 class ImageCaptureActivity : AppCompatActivity() {
 
     private lateinit var viewFinder: TextureView
     private lateinit var imageCaptureButton: ImageButton
     private lateinit var toolbarTitle: TextView
+    private val deviceOrientation by inject<DeviceOrientation>()
 
     companion object {
         private const val SELFIE_MODE = "SELFIE_MODE"
@@ -71,6 +78,7 @@ class ImageCaptureActivity : AppCompatActivity() {
         // Build the image capture use case and attach button click listener
         val imageCapture = ImageCapture(imageCaptureConfig)
         imageCaptureButton.setOnClickListener {
+            deviceOrientation.takeSnapshotAndDisable()
             imageCapture.takePicture(
                 file,
                 object : ImageCapture.OnImageSavedListener {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/MainActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/MainActivity.kt
@@ -25,6 +25,7 @@ import org.greenstand.android.TreeTracker.analytics.Analytics
 import org.greenstand.android.TreeTracker.application.Permissions
 import org.greenstand.android.TreeTracker.fragments.DataFragment
 import org.greenstand.android.TreeTracker.fragments.MapsFragmentDirections
+import org.greenstand.android.TreeTracker.models.DeviceOrientation
 import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.LanguageSwitcher
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
@@ -41,6 +42,7 @@ class MainActivity : AppCompatActivity(), ActivityCompat.OnRequestPermissionsRes
     private val locationUpdateManager: LocationUpdateManager by inject()
     private val locationDataCapturer: LocationDataCapturer by inject()
     private val stepCounter: StepCounter by inject()
+    private val deviceOrientation: DeviceOrientation by inject()
     private val sharedPreferences: SharedPreferences by inject()
     private var fragment: Fragment? = null
     /**
@@ -52,6 +54,7 @@ class MainActivity : AppCompatActivity(), ActivityCompat.OnRequestPermissionsRes
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(stepCounter)
+        lifecycle.addObserver(deviceOrientation)
         languageSwitcher.applyCurrentLanguage(this)
 
         setContentView(R.layout.activity_main)
@@ -149,6 +152,7 @@ class MainActivity : AppCompatActivity(), ActivityCompat.OnRequestPermissionsRes
     public override fun onDestroy() {
         super.onDestroy()
         lifecycle.removeObserver(stepCounter)
+        lifecycle.removeObserver(deviceOrientation)
     }
 
     private fun areNecessaryPermissionsNotGranted(): Boolean {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
@@ -11,6 +11,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import org.greenstand.android.TreeTracker.analytics.Analytics
 import org.greenstand.android.TreeTracker.api.ObjectStorageClient
 import org.greenstand.android.TreeTracker.background.SyncNotificationManager
+import org.greenstand.android.TreeTracker.models.DeviceOrientation
 import org.greenstand.android.TreeTracker.models.LanguageSwitcher
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
@@ -61,11 +62,11 @@ val appModule = module {
 
     viewModel { DataViewModel(get(), get(), get(), get()) }
 
-    viewModel { MapViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { MapViewModel(get(), get(), get(), get(), get(), get(), get()) }
 
     viewModel { TreePreviewViewModel(get(), get()) }
 
-    viewModel { NewTreeViewModel(get(), get(), get(), get(), get(), get()) }
+    viewModel { NewTreeViewModel(get(), get(), get(), get(), get(), get(), get()) }
 
     single { WorkManager.getInstance(get()) }
 
@@ -106,6 +107,8 @@ val appModule = module {
     }
 
     single { StepCounter(get(), get()) }
+
+    single { DeviceOrientation(get()) }
 
     factory { PreferencesMigrator(get(), get()) }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/DeviceOrientation.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/DeviceOrientation.kt
@@ -1,0 +1,54 @@
+package org.greenstand.android.TreeTracker.models
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import timber.log.Timber
+
+class DeviceOrientation(
+    private val sensorManager: SensorManager
+) : LifecycleObserver {
+
+    val orientationEventListener = OrientationEventListener()
+    var rotationMatrixSnapshot: FloatArray? = null
+        private set
+    private var rotationMatrix: FloatArray = FloatArray(16)
+    private val rotationVectorSensor = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+
+    fun enable() {
+        Timber.d("DeviceOrientation - registering rotation vector sensor")
+        sensorManager.registerListener(
+            orientationEventListener, rotationVectorSensor, SensorManager.SENSOR_DELAY_FASTEST)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    fun disable() {
+        Timber.d("DeviceOrientation - unregistering rotation vector sensor")
+        sensorManager.unregisterListener(orientationEventListener)
+    }
+
+    fun takeSnapshotAndDisable() {
+        Timber.d("DeviceOrientation - snapshot rotation matrix")
+        rotationMatrixSnapshot = rotationMatrix
+        disable()
+    }
+
+    inner class OrientationEventListener : SensorEventListener {
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+            // Ignore
+        }
+
+        override fun onSensorChanged(event: SensorEvent?) {
+            event?.let {
+                SensorManager.getRotationMatrixFromVector(rotationMatrix, it.values)
+                Timber.d("DeviceOrientation - Rotation Matrix " +
+                        "[${rotationMatrix.joinToString(",")}]")
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/StepCounter.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/StepCounter.kt
@@ -20,13 +20,18 @@ class StepCounter(
     private val stepCounter = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
     private val stepCountEventListener = StepCountEventListener()
 
+    private val BASE_KEY = PrefKeys.SESSION + PrefKey("steps")
+    private val ABS_STEP_COUNT = BASE_KEY + PrefKey("abs-step-count")
+    private val ABS_STEP_COUNT_ON_TREE_CAPTURE = BASE_KEY +
+            PrefKey("abs-step-count-on-tree-capture")
+
     var absoluteStepCount: Int?
         get() = preferences.getInt(ABS_STEP_COUNT)
         private set(value) = preferences.edit().putInt(ABS_STEP_COUNT, value ?: 0).apply()
 
     var absoluteStepCountOnTreeCapture: Int?
         get() = preferences.getInt(ABS_STEP_COUNT_ON_TREE_CAPTURE)
-        set(value) = preferences
+        private set(value) = preferences
             .edit().putInt(ABS_STEP_COUNT_ON_TREE_CAPTURE, value ?: 0).apply()
 
     fun enable() {
@@ -41,6 +46,10 @@ class StepCounter(
         sensorManager.unregisterListener(stepCountEventListener)
     }
 
+    fun snapshotAbsoluteStepCountOnTreeCapture() {
+        absoluteStepCountOnTreeCapture = absoluteStepCount
+    }
+
     inner class StepCountEventListener : SensorEventListener {
         override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
             // Ignore
@@ -52,12 +61,5 @@ class StepCounter(
                 Timber.d("StepCounter: Step count [${it.values[0].toInt()}]")
             }
         }
-    }
-
-    companion object {
-        private val BASE_KEY = PrefKeys.SESSION + PrefKey("steps")
-        val ABS_STEP_COUNT = BASE_KEY + PrefKey("abs-step-count")
-        val ABS_STEP_COUNT_ON_TREE_CAPTURE = BASE_KEY +
-                PrefKey("abs-step-count-on-tree-capture")
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/StepCounter.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/StepCounter.kt
@@ -20,11 +20,6 @@ class StepCounter(
     private val stepCounter = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
     private val stepCountEventListener = StepCountEventListener()
 
-    private val BASE_KEY = PrefKeys.SESSION + PrefKey("steps")
-    private val ABS_STEP_COUNT = BASE_KEY + PrefKey("abs-step-count")
-    private val ABS_STEP_COUNT_ON_TREE_CAPTURE = BASE_KEY +
-            PrefKey("abs-step-count-on-tree-capture")
-
     var absoluteStepCount: Int?
         get() = preferences.getInt(ABS_STEP_COUNT)
         private set(value) = preferences.edit().putInt(ABS_STEP_COUNT, value ?: 0).apply()
@@ -61,5 +56,12 @@ class StepCounter(
                 Timber.d("StepCounter: Step count [${it.values[0].toInt()}]")
             }
         }
+    }
+
+    companion object {
+        private val BASE_KEY = PrefKeys.SESSION + PrefKey("steps")
+        private val ABS_STEP_COUNT = BASE_KEY + PrefKey("abs-step-count")
+        private val ABS_STEP_COUNT_ON_TREE_CAPTURE = BASE_KEY +
+                PrefKey("abs-step-count-on-tree-capture")
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/Tree.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/Tree.kt
@@ -31,5 +31,6 @@ class Tree(
         // a tree minus the last absolute step count recorded when capturing a previous tree. This
         // is the indicator for the number of steps taken between two trees.
         const val DELTA_STEP_COUNT_KEY = "delta_step_count"
+        const val ROTATION_MATRIX_KEY = "rotation_matrix"
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import org.greenstand.android.TreeTracker.models.DeviceOrientation
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.StepCounter
@@ -23,7 +24,8 @@ class MapViewModel constructor(
     private val locationDataCapturer: LocationDataCapturer,
     locationUpdateManager: LocationUpdateManager,
     private val user: User,
-    private val stepCounter: StepCounter
+    private val stepCounter: StepCounter,
+    private val deviceOrientation: DeviceOrientation
 ) : ViewModel() {
 
     val checkInStatusLiveData = MutableLiveData<Boolean>()
@@ -58,6 +60,7 @@ class MapViewModel constructor(
     fun turnOnTreeCaptureMode() {
         locationDataCapturer.turnOnTreeCaptureMode()
         stepCounter.enable()
+        deviceOrientation.enable()
     }
 
     suspend fun resolveLocationConvergence() {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/NewTreeViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/NewTreeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import java.util.UUID
 import kotlin.math.roundToInt
 import org.greenstand.android.TreeTracker.analytics.Analytics
+import org.greenstand.android.TreeTracker.models.DeviceOrientation
 import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
@@ -22,7 +23,8 @@ class NewTreeViewModel(
     private val locationDataCapturer: LocationDataCapturer,
     private val createTreeUseCase: CreateTreeUseCase,
     private val analytics: Analytics,
-    private val stepCounter: StepCounter
+    private val stepCounter: StepCounter,
+    private val deviceOrientation: DeviceOrientation
 ) : ViewModel() {
 
     val onTreeSaved: MutableLiveData<Unit> = MutableLiveData()
@@ -68,7 +70,10 @@ class NewTreeViewModel(
         val deltaSteps = absoluteStepCount - lastStepCountWhenCreatingTree
         newTree.addTreeAttribute(Tree.ABS_STEP_COUNT_KEY, absoluteStepCount.toString())
         newTree.addTreeAttribute(Tree.DELTA_STEP_COUNT_KEY, deltaSteps.toString())
-
+        deviceOrientation.rotationMatrixSnapshot?.let {
+            newTree.addTreeAttribute(
+                Tree.ROTATION_MATRIX_KEY, it.joinToString(","))
+        }
         if (newTree.content.isNotBlank()) {
             analytics.treeNoteAdded(newTree.content.length)
         }
@@ -79,7 +84,7 @@ class NewTreeViewModel(
             createTreeUseCase.execute(newTree)
             // Assign the current absolute step count to 'absoluteStepCountOnTreeCapture' to
             // enable step count delta calculation for the next tree capture
-            stepCounter.absoluteStepCountOnTreeCapture = absoluteStepCount
+            stepCounter.snapshotAbsoluteStepCountOnTreeCapture()
             stepCounter.disable()
             onTreeSaved.postValue(Unit)
             navigateBack.postValue(Unit)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/TreeHeightViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/TreeHeightViewModel.kt
@@ -61,9 +61,9 @@ class TreeHeightViewModel(
                     toastMessageLiveData.postValue(R.string.tree_saved)
                     analytics.treeHeightMeasured(treeColor!!)
                     onFinishedLiveData.postValue(Unit)
-                    // Assign the current absolute step count to 'absoluteStepCountOnTreeCapture'
+                    // Snapshot the current absolute step count to 'absoluteStepCountOnTreeCapture'
                     // variable to calculate future step count deltas
-                    stepCounter.absoluteStepCountOnTreeCapture = stepCounter.absoluteStepCount
+                    stepCounter.snapshotAbsoluteStepCountOnTreeCapture()
                     stepCounter.disable()
                 }
                 ?: run { toastMessageLiveData.postValue(R.string.tree_height_save_error) }


### PR DESCRIPTION
The change adds the feature to capture device orientation data (Rotation matrix) using Rotation Vector Sensor.
This addresses the issue https://github.com/Greenstand/treetracker-android/issues/465.

Change includes:
- Capturing the snapshot of the rotation matrix when the camera button is clicked
- The rotation matrix is a float array of length size 16
- The captured rotation matrix snapshot is added a tree attribute as a string with values seperated by commas

The change is tested in a samsung galaxy s8 device