### PR TITLE
Allow convergence to un-converge within a  tree capture session

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/MainActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/MainActivity.kt
@@ -151,8 +151,12 @@ class MainActivity : AppCompatActivity(), ActivityCompat.OnRequestPermissionsRes
 
     public override fun onDestroy() {
         super.onDestroy()
+        locationDataCapturer.turnOffTreeCaptureMode()
         lifecycle.removeObserver(stepCounter)
         lifecycle.removeObserver(deviceOrientation)
+        // This is address the use case when the app screen is exited when in
+        // in a tree capture mode
+        locationDataCapturer.turnOffTreeCaptureMode()
     }
 
     private fun areNecessaryPermissionsNotGranted(): Boolean {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/MainActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/MainActivity.kt
@@ -151,10 +151,9 @@ class MainActivity : AppCompatActivity(), ActivityCompat.OnRequestPermissionsRes
 
     public override fun onDestroy() {
         super.onDestroy()
-        locationDataCapturer.turnOffTreeCaptureMode()
         lifecycle.removeObserver(stepCounter)
         lifecycle.removeObserver(deviceOrientation)
-        // This is address the use case when the app screen is exited when in
+        // This is to address the use case when the app screen is exited while
         // in a tree capture mode
         locationDataCapturer.turnOffTreeCaptureMode()
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/NewTreeFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/NewTreeFragment.kt
@@ -101,6 +101,7 @@ class NewTreeFragment :
 
         fragmentNewTreeSave.setOnClickListener {
             it.vibrate()
+            vm.newTreePhotoCaptured()
             viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                 vm.createTree(
                     fragmentNewTreeNote.text.toString(),
@@ -122,11 +123,6 @@ class NewTreeFragment :
         }
     }
 
-    override fun onStop() {
-        vm.newTreeCaptureCancelled()
-        super.onStop()
-    }
-
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<String>,
@@ -141,7 +137,6 @@ class NewTreeFragment :
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        vm.newTreePhotoCaptured()
         if (data != null && resultCode == Activity.RESULT_OK) {
             vm.photoPath = data.getStringExtra(ValueHelper.TAKEN_IMAGE_PATH)
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
@@ -16,11 +16,11 @@ import java.util.UUID
 import kotlin.math.pow
 import kotlin.math.sqrt
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.database.entity.LocationDataEntity
 import org.greenstand.android.TreeTracker.utilities.LocationDataConfig
@@ -156,7 +156,7 @@ class LocationDataCapturer(
     private val locationObserver: Observer<Location?> = Observer { location ->
         location?.apply {
 
-            if (isInTreeCaptureMode() && !isConvergenceWithinRange()) {
+            if (isInTreeCaptureMode()) {
 
                 val evictedLocation: Location? = if (locationsDeque.size >= CONVERGENCE_DATA_SIZE)
                     locationsDeque.pollFirst() else null
@@ -187,6 +187,8 @@ class LocationDataCapturer(
                     if (longStdDev != null && latStdDev != null) {
                         if (longStdDev < LONG_STD_DEV && latStdDev < LAT_STD_DEV) {
                             convergenceStatus = ConvergenceStatus.CONVERGED
+                        } else {
+                            convergenceStatus = ConvergenceStatus.NOT_CONVERGED
                         }
                     }
                 }
@@ -276,7 +278,7 @@ class Convergence(val locations: List<Location>) {
     }
 
     /**
-     * Implementation based on the following answer found here since this seems to be a good
+     * Implementation based on the following answer found in stackexchange since it seems to be a good
      * approximation to the running window standard deviation calculation. Considered Welford's
      * method of computing variance but it calculates running cumulative variance but we need
      * sliding window computation here.

--- a/app/src/test/java/org/greenstand/android/TreeTracker/models/LocationDataCapturerTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/models/LocationDataCapturerTest.kt
@@ -27,13 +27,17 @@ class LocationDataCapturerTest {
 
     @MockK(relaxed = true)
     private lateinit var user: User
+
     @MockK(relaxed = true)
     private lateinit var locationUpdateManager: LocationUpdateManager
+
     @MockK(relaxed = true)
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var preferences: Preferences
+
     @MockK(relaxed = true)
     private lateinit var treeTrackerDAO: TreeTrackerDAO
+
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
 
@@ -101,6 +105,7 @@ class LocationDataCapturerTest {
         Pair(-122.08400021999, 37.42149489),
         Pair(-122.0840086753, 37.42149481)
     )
+
     @Test
     fun convergenceWithinRange() {
 
@@ -126,6 +131,7 @@ class LocationDataCapturerTest {
         Pair(-122.0913121999, 37.42149489),
         Pair(-122.0773486753, 37.42149481)
     )
+
     @Test
     fun convergenceNotWithinRange() {
         val locationsLiveData = MutableLiveData<Location>()
@@ -141,5 +147,45 @@ class LocationDataCapturerTest {
         }
 
         assertFalse(locationDataCapturer.isConvergenceWithinRange())
+    }
+
+    val locationsWithLowAndHighVariance = listOf(
+        Pair(-122.08400001, 37.42149486),
+        Pair(-122.08400111, 37.42149487),
+        Pair(-122.08400021519, 37.42149483),
+        Pair(-122.08400021999, 37.42149489),
+        Pair(-122.0840086753, 37.42149481),
+        Pair(-122.0913121999, 37.42149489),
+        Pair(-122.0773486753, 37.42149481)
+    )
+    @Test
+    fun unconvergeWhenGPSWanders() {
+        val locationsLiveData = MutableLiveData<Location>()
+        every { locationUpdateManager.locationUpdateLiveData } returns locationsLiveData
+        locationDataCapturer.start()
+        locationDataCapturer.turnOnTreeCaptureMode()
+
+        for (i in 0..4) {
+            val location = mockk<Location>(relaxed = true)
+            every { location.longitude } returns locationValuesLowVariance[i].first
+            every { location.latitude } returns locationValuesLowVariance[i].second
+            locationsLiveData.postValue(location)
+        }
+
+        assertTrue(
+            "Converges with low variance location values",
+            locationDataCapturer.isConvergenceWithinRange()
+        )
+
+        for (i in 5..6) {
+            val location = mockk<Location>(relaxed = true)
+            every { location.longitude } returns locationsWithLowAndHighVariance[i].first
+            every { location.latitude } returns locationsWithLowAndHighVariance[i].second
+            locationsLiveData.postValue(location)
+        }
+        assertFalse(
+            "location unconverges when gps values wander",
+            locationDataCapturer.isConvergenceWithinRange()
+        )
     }
 }


### PR DESCRIPTION
This change addresses the issue reported in https://github.com/Greenstand/treetracker-android/issues/505.

Convergence computation is continued even after convergence is attained to detect any changes and recorded until the tree capture ends on saving the tree.

Testing done on both greenstand and justdigit flavor