### PR TITLE
Fix the image resize on tree capture from being ignored

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -282,11 +282,10 @@ play {
 apply plugin: 'com.google.gms.google-services'
 
 ktlint {
-    version.set("0.22.0")
-    verbose.set(true)
+    version.set("0.39.0")
     android.set(true)
     outputToConsole.set(true)
-    outputColorName.set("RED")
+    outputColorName="RED"
 }
 
 afterEvaluate {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -285,7 +285,7 @@ ktlint {
     version.set("0.39.0")
     android.set(true)
     outputToConsole.set(true)
-    outputColorName="RED"
+    outputColorName.set("RED")
 }
 
 afterEvaluate {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
@@ -92,7 +92,7 @@ class ImageCaptureActivity : AppCompatActivity() {
                     }
 
                     override fun onImageSaved(file: File) {
-                        ImageUtils.resizedImage(file.absolutePath)
+                        ImageUtils.resizeImage(file.absolutePath)
                         Timber.tag("CameraXApp").d("Photo capture succeeded: ${file.absolutePath}")
                         val focusMetric = testFocusQuality(file)
 
@@ -113,7 +113,8 @@ class ImageCaptureActivity : AppCompatActivity() {
                         setResult(Activity.RESULT_OK, data)
                         finish()
                     }
-                })
+                }
+            )
         }
         CameraX.bindToLifecycle(this, preview, imageCapture)
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
@@ -8,15 +8,15 @@ import android.graphics.Matrix
 import android.util.Base64
 import androidx.exifinterface.media.ExifInterface
 import com.amazonaws.util.IOUtils
-import timber.log.Timber
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Date
 import kotlin.math.abs
 import kotlin.math.ceil
+import timber.log.Timber
 
 object ImageUtils {
 
@@ -93,10 +93,14 @@ object ImageUtils {
         Timber.d("rotationAngle $rotationAngle")
 
         val matrix = Matrix()
-        matrix.setRotate(rotationAngle.toFloat(), bitmap.width.toFloat() / 2,
-                bitmap.height.toFloat() / 2)
-        return Bitmap.createBitmap(bitmap, 0, 0,
-                bmOptions.outWidth, bmOptions.outHeight, matrix, true)
+        matrix.setRotate(
+            rotationAngle.toFloat(), bitmap.width.toFloat() / 2,
+            bitmap.height.toFloat() / 2
+        )
+        return Bitmap.createBitmap(
+            bitmap, 0, 0,
+            bmOptions.outWidth, bmOptions.outHeight, matrix, true
+        )
     }
 
     /**
@@ -122,7 +126,7 @@ object ImageUtils {
     /**
      * out put image data pixels to console
      */
-     fun printImage(image: IntArray, rows: Int, cols: Int) {
+    fun printImage(image: IntArray, rows: Int, cols: Int) {
         var counter = 0.0
 
         println()
@@ -146,7 +150,10 @@ object ImageUtils {
         BitmapFactory.decodeFile(imagePath, bmOptions)
         val imageWidth = bmOptions.outWidth
 
-        var sampleSize = Math.ceil((imageWidth.toFloat() / scaleToWidth.toFloat()).toDouble()).toInt()
+        var sampleSize = Math.ceil(
+            (imageWidth.toFloat() / scaleToWidth.toFloat())
+                .toDouble()
+        ).toInt()
         // If the original image is smaller than required, don't sample
         if (sampleSize < 1) {
             sampleSize = 1
@@ -179,7 +186,7 @@ object ImageUtils {
         }
 
         val gimg = getGrayPixels(img)
-       return gimg
+        return gimg
     }
 
     /**
@@ -190,7 +197,7 @@ object ImageUtils {
         val ran = kotlin.random.Random(System.currentTimeMillis()).nextInt(0, 10)
         println(ran)
         if (ran > 0) {
-           return applyGaussianKernel(image, ran, 2.0)
+            return applyGaussianKernel(image, ran, 2.0)
         }
         return image
     }
@@ -272,7 +279,11 @@ object ImageUtils {
      *  To test the focus detection, we need to blur some images.
      */
 
-    fun applyGaussianKernel(image: Array<Array<Int>>, kWidth: Int, sigma: Double): Array<Array<Int>> {
+    fun applyGaussianKernel(
+        image: Array<Array<Int>>,
+        kWidth: Int,
+        sigma: Double
+    ): Array<Array<Int>> {
         val imRows = image.lastIndex + 1
         val imCols = image.get(0).lastIndex + 1
 
@@ -285,7 +296,9 @@ object ImageUtils {
 
         for (r in rowStart until rowEnd) {
             for (c in colStart until colEnd) {
-                result[r][c] = performCorrelation(image, kernelAndNorm.first, r, c, kWidth, kernelAndNorm.second).toInt()
+                result[r][c] = performCorrelation(
+                    image, kernelAndNorm.first, r, c, kWidth, kernelAndNorm.second
+                ).toInt()
             }
         }
         return result
@@ -330,7 +343,7 @@ object ImageUtils {
         return sum / (rows * cols).toDouble()
     }
 
-    fun resizedImage(path: String): Bitmap {
+    fun resizeImage(path: String) {
 
         /* There isn't enough memory to open up more than a couple camera photos */
         /* So pre-scale the target bitmap into which the file is decoded */
@@ -366,15 +379,19 @@ object ImageUtils {
         /* Decode the JPEG file into a Bitmap */
         val bitmap = BitmapFactory.decodeFile(path, bmOptions)
 
-        val rotatedBitmap = Bitmap.createBitmap(bitmap, 0, 0,
-            bmOptions.outWidth, bmOptions.outHeight, Matrix(), true)
+        val rotatedBitmap = Bitmap.createBitmap(
+            bitmap, 0, 0,
+            bmOptions.outWidth, bmOptions.outHeight, Matrix(), true
+        )
 
         val compressionQuality = 100
         val byteArrayBitmapStream = ByteArrayOutputStream()
-        rotatedBitmap.compress(Bitmap.CompressFormat.PNG, compressionQuality,
-            byteArrayBitmapStream)
-
-        return rotatedBitmap
+        rotatedBitmap.compress(
+            Bitmap.CompressFormat.JPEG, compressionQuality,
+            byteArrayBitmapStream
+        )
+        val fileOutputStream = FileOutputStream(path)
+        byteArrayBitmapStream.writeTo(fileOutputStream)
     }
 
     fun base64Image(path: String): String {
@@ -413,14 +430,18 @@ object ImageUtils {
         /* Decode the JPEG file into a Bitmap */
         val bitmap = BitmapFactory.decodeFile(path, bmOptions)
 
-        val rotatedBitmap = Bitmap.createBitmap(bitmap, 0, 0,
-            bmOptions.outWidth, bmOptions.outHeight, Matrix(), true)
+        val rotatedBitmap = Bitmap.createBitmap(
+            bitmap, 0, 0,
+            bmOptions.outWidth, bmOptions.outHeight, Matrix(), true
+        )
 
         val compressionQuality = 80
         val encodedImage: String
         val byteArrayBitmapStream = ByteArrayOutputStream()
-        rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, compressionQuality,
-            byteArrayBitmapStream)
+        rotatedBitmap.compress(
+            Bitmap.CompressFormat.JPEG, compressionQuality,
+            byteArrayBitmapStream
+        )
         val b = byteArrayBitmapStream.toByteArray()
         encodedImage = Base64.encodeToString(b, Base64.DEFAULT)
 


### PR DESCRIPTION
The change utilizes the resizing of the image that happens when the captured image is really large.
The resized image data was ignored and this is fixed in this change.