### PR TITLE
Dismiss keyboard when clicking on gps convergence button

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/NewTreeFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/NewTreeFragment.kt
@@ -22,6 +22,7 @@ import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.utilities.CameraHelper
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
 import org.greenstand.android.TreeTracker.utilities.ValueHelper
+import org.greenstand.android.TreeTracker.utilities.dismissKeyboard
 import org.greenstand.android.TreeTracker.utilities.vibrate
 import org.greenstand.android.TreeTracker.utilities.visibleIf
 import org.greenstand.android.TreeTracker.view.CustomToast
@@ -72,32 +73,51 @@ class NewTreeFragment :
             fragmentNewTreeSave.text = getString(R.string.save)
         }
 
-        vm.accuracyLiveData.observe(this, Observer {
-            fragmentNewTreeGpsAccuracy.text =
-                fragmentNewTreeGpsAccuracy.context.getString(R.string.gps_accuracy_double_colon, it)
-        })
+        vm.accuracyLiveData.observe(
+            this,
+            Observer {
+                fragmentNewTreeGpsAccuracy.text = fragmentNewTreeGpsAccuracy
+                    .context.getString(R.string.gps_accuracy_double_colon, it)
+            }
+        )
 
-        vm.navigateBack.observe(this, Observer {
-            vm.newTreeCaptureCancelled()
-            findNavController().popBackStack()
-        })
+        vm.navigateBack.observe(
+            this,
+            Observer {
+                vm.newTreeCaptureCancelled()
+                findNavController().popBackStack()
+            }
+        )
 
-        vm.navigateToTreeHeight.observe(this, Observer {
-            findNavController()
-                .navigate(NewTreeFragmentDirections.actionNewTreeFragmentToTreeHeightFragment(it))
-        })
+        vm.navigateToTreeHeight.observe(
+            this,
+            Observer {
+                findNavController().navigate(
+                    NewTreeFragmentDirections.actionNewTreeFragmentToTreeHeightFragment(it)
+                )
+            }
+        )
 
-        vm.onInsufficientGps.observe(this, Observer {
-            CustomToast.showToast("Insufficient GPS accuracy")
-        })
+        vm.onInsufficientGps.observe(
+            this,
+            Observer {
+                CustomToast.showToast("Insufficient GPS accuracy")
+            }
+        )
 
-        vm.onTreeSaved.observe(this, Observer {
-            CustomToast.showToast("Tree saved")
-        })
+        vm.onTreeSaved.observe(
+            this,
+            Observer {
+                CustomToast.showToast("Tree saved")
+            }
+        )
 
-        vm.onTakePicture.observe(this, Observer {
-            CameraHelper.takePictureForResult(this, selfie = false)
-        })
+        vm.onTakePicture.observe(
+            this,
+            Observer {
+                CameraHelper.takePictureForResult(this, selfie = false)
+            }
+        )
 
         fragmentNewTreeSave.setOnClickListener {
             it.vibrate()
@@ -105,11 +125,13 @@ class NewTreeFragment :
             viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                 vm.createTree(
                     fragmentNewTreeNote.text.toString(),
-                    fragmentNewTreeDBH.text.toString())
+                    fragmentNewTreeDBH.text.toString()
+                )
             }
         }
 
         fragmentNewTreeGPS.setOnClickListener {
+            requireActivity().dismissKeyboard()
             viewLifecycleOwner.lifecycleScope.launch {
                 progressBar.visibility = View.VISIBLE
                 progressBar.setOnClickListener {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ViewUtils.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ViewUtils.kt
@@ -2,12 +2,14 @@ package org.greenstand.android.TreeTracker.utilities
 
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
+import android.app.Activity
+import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.drawable.ColorDrawable
 import android.view.HapticFeedbackConstants
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import com.google.android.material.card.MaterialCardView
-
 
 fun View.animateColor(toColor: Int, fromColor: Int = color, durationMsec: Long = 300) {
     ValueAnimator.ofObject(ArgbEvaluator(), fromColor, toColor).apply {
@@ -17,11 +19,10 @@ fun View.animateColor(toColor: Int, fromColor: Int = color, durationMsec: Long =
     }
 }
 
-
 val View.color: Int
     get() {
         val back = background
-        return when(back) {
+        return when (back) {
             is ColorDrawable -> back.color
             is ColorStateList -> (back.current as ColorDrawable).color
             else -> 0
@@ -32,7 +33,6 @@ val MaterialCardView.cardColor: Int
     get() {
         return cardBackgroundColor.defaultColor
     }
-
 
 fun View.vibrate() {
     performHapticFeedback(
@@ -46,5 +46,14 @@ fun View.visibleIf(predicate: Boolean, default: Int = View.GONE) {
         View.VISIBLE
     } else {
         default
+    }
+}
+
+fun Activity.dismissKeyboard() {
+    val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+    if (inputMethodManager.isActive) {
+        this.currentFocus?.let {
+            inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0)
+        }
     }
 }


### PR DESCRIPTION
Addresses the issue reported in https://github.com/Greenstand/treetracker-android/issues/521.

The keyboard folds when clicking on the GPS convergence button letting the user see the save button in NewTreeFragment.