### PR TITLE
Fix the escape characters in location data json string on upload

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenstand.android.TreeTracker.api.ObjectStorageClient
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
+import org.greenstand.android.TreeTracker.models.LocationData
 import org.greenstand.android.TreeTracker.utilities.md5
 import timber.log.Timber
 
@@ -20,7 +21,9 @@ class UploadLocationDataUseCase(
         try {
             withContext(Dispatchers.IO) {
                 val locationEntities = dao.getTreeLocationData()
-                val locations = locationEntities.map { it.locationDataJson }
+                val locations = locationEntities.map {
+                    gson.fromJson(it.locationDataJson, LocationData::class.java)
+                }
                 val treeLocJsonArray = gson.toJson(locations)
                 storageClient.uploadBundle(
                     treeLocJsonArray,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenstand.android.TreeTracker.api.ObjectStorageClient
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
-import org.greenstand.android.TreeTracker.models.LocationData
 import org.greenstand.android.TreeTracker.utilities.md5
 import timber.log.Timber
 
@@ -21,10 +20,8 @@ class UploadLocationDataUseCase(
         try {
             withContext(Dispatchers.IO) {
                 val locationEntities = dao.getTreeLocationData()
-                val locations = locationEntities.map {
-                    gson.fromJson(it.locationDataJson, LocationData::class.java)
-                }
-                val treeLocJsonArray = gson.toJson(locations)
+                val locations = locationEntities.map { it.locationDataJson }
+                val treeLocJsonArray = locations.toString()
                 storageClient.uploadBundle(
                     treeLocJsonArray,
                     "loc_data_${treeLocJsonArray.md5()}"


### PR DESCRIPTION
When uploading location data as json array, the list of json string values for locations from the db causes escape characters to be introduced when marshalling the array one more time.

The fix is to not marshall but instead use simple toString() on the list of string array to create the desired array of  strings with json representations for location data.