### PR TITLE
Conform to the json format required for location data upload

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenstand.android.TreeTracker.api.ObjectStorageClient
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
+import org.greenstand.android.TreeTracker.models.LocationData
 import org.greenstand.android.TreeTracker.utilities.md5
 import timber.log.Timber
 
@@ -20,8 +21,10 @@ class UploadLocationDataUseCase(
         try {
             withContext(Dispatchers.IO) {
                 val locationEntities = dao.getTreeLocationData()
-                val locations = locationEntities.map { it.locationDataJson }
-                val treeLocJsonArray = locations.toString()
+                val locations = locationEntities.map {
+                    gson.fromJson(it.locationDataJson, LocationData::class.java)
+                }
+                val treeLocJsonArray = gson.toJson(mapOf("locations" to locations))
                 storageClient.uploadBundle(
                     treeLocJsonArray,
                     "loc_data_${treeLocJsonArray.md5()}"


### PR DESCRIPTION
The change is to wrap the array of location data in a json object under the attribute locations.

The new format takes the following form:
{ "locations":[{"accuracy":6.432,"capturedAt":1601756569360,"convergenceStatus":null,"latitude":47.06804996,"longitude":-122.93840958,"planterCheckInId":1,"treeUuid":null}]

This was missed in my earlier PR that addressed the escape characters reported in the issue [https://github.com/Greenstand/treetracker-android/issues/534](534). 

One thing this change couldn't avoid is having to unmarshall a seralized json string back to `LocationData` object and populating the array before marshalling the wrapped json array back to a json string. This is due to the escape characters that get introduced when serializing a json string.

