### PR TITLE
Handle the image rotation for profile picture

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
@@ -92,7 +92,7 @@ class ImageCaptureActivity : AppCompatActivity() {
                     }
 
                     override fun onImageSaved(file: File) {
-                        ImageUtils.resizeImage(file.absolutePath)
+                        ImageUtils.resizeImage(file.absolutePath, captureSelfie)
                         Timber.tag("CameraXApp").d("Photo capture succeeded: ${file.absolutePath}")
                         val focusMetric = testFocusQuality(file)
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
@@ -343,7 +343,7 @@ object ImageUtils {
         return sum / (rows * cols).toDouble()
     }
 
-    fun resizeImage(path: String) {
+    fun resizeImage(path: String, captureSelfie: Boolean) {
 
         /* There isn't enough memory to open up more than a couple camera photos */
         /* So pre-scale the target bitmap into which the file is decoded */
@@ -379,7 +379,8 @@ object ImageUtils {
         /* Decode the JPEG file into a Bitmap */
         val bitmap = BitmapFactory.decodeFile(path, bmOptions)
         val matrix = Matrix()
-        matrix.setRotate(90f) // Offsets the -90 degree rotation on resize
+        val rotationOffset = if (captureSelfie) -90f else 90f
+        matrix.setRotate(rotationOffset) // Offsets the -90 degree rotation on resize
         val rotatedBitmap = Bitmap.createBitmap(
             bitmap, 0, 0,
             bmOptions.outWidth, bmOptions.outHeight, matrix, true


### PR DESCRIPTION
The fix made earlier for offsetting rotation that happens when resizing the tree image capture doesn't address the offset for profile pictures taken at the time of registration. This fix addresses it. Both the tree captures and profile pictures rotation are offset when resized in this fix and reduces in size.
