### PR TITLE
Remove the condition for location accuracy to reach threshold before adding tree

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,7 +94,6 @@ android {
         release {
             minifyEnabled true
             resValue "string", "app_name", "Tree Tracker"
-            buildConfigField "Boolean", "GPS_ACCURACY", "true"
             buildConfigField "String", "OBJECT_STORAGE_IDENTITY_POOL_ID", "\"${s3_production_identity_pool_id}\""
             buildConfigField 'String', 'OBJECT_STORAGE_ENDPOINT', '"eu-central-1"'
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_IMAGES', '"treetracker-production-images"'
@@ -109,7 +108,6 @@ android {
         prerelease {
             initWith(debug)
             applicationIdSuffix ".prerelease"
-            buildConfigField "Boolean", "GPS_ACCURACY", "false"
             buildConfigField "String", "OBJECT_STORAGE_IDENTITY_POOL_ID", "\"${s3_production_identity_pool_id}\""
             buildConfigField 'String', 'OBJECT_STORAGE_ENDPOINT', '"eu-central-1"'
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_IMAGES', '"treetracker-production-images"'
@@ -123,7 +121,6 @@ android {
         debug {
             applicationIdSuffix ".debug"
             resValue "string", "app_name", "Tree Tracker(debug)"
-            buildConfigField "Boolean", "GPS_ACCURACY", "true"
             buildConfigField "String", "OBJECT_STORAGE_IDENTITY_POOL_ID", "\"${s3_test_identity_pool_id}\""
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_IMAGES', '"treetracker-test-images"'
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_BATCH_UPLOADS', '"treetracker-test-batch-uploads"'
@@ -135,7 +132,6 @@ android {
         beta {
             applicationIdSuffix ".test"
             resValue "string", "app_name", "Tree Tracker(test)"
-            buildConfigField "Boolean", "GPS_ACCURACY", "true"
             buildConfigField "String", "OBJECT_STORAGE_IDENTITY_POOL_ID", "\"${s3_test_identity_pool_id}\""
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_IMAGES', '"treetracker-test-images"'
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_BATCH_UPLOADS', '"treetracker-test-batch-uploads"'
@@ -150,7 +146,6 @@ android {
             initWith(debug)
             applicationIdSuffix ".dev"
             resValue "string", "app_name", "Tree Tracker(dev)"
-            buildConfigField "Boolean", "GPS_ACCURACY", "false"
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_IMAGES', '"treetracker-dev-images"'
             buildConfigField 'String', 'OBJECT_STORAGE_BUCKET_BATCH_UPLOADS', '"treetracker-dev-batch-uploads"'
             buildConfigField 'Boolean', 'ENABLE_FABRIC', "false"

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/MapsFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/MapsFragment.kt
@@ -3,14 +3,11 @@ package org.greenstand.android.TreeTracker.fragments
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.graphics.Color
-import android.location.Location
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnClickListener
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.Group
@@ -24,7 +21,6 @@ import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.clustering.ClusterManager
-import kotlin.math.roundToInt
 import kotlinx.android.synthetic.main.activity_main.toolbarTitle
 import kotlinx.android.synthetic.main.fragment_map.addTreeButton
 import kotlinx.android.synthetic.main.fragment_map.goToUploadsButton
@@ -37,11 +33,9 @@ import kotlinx.coroutines.withContext
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.map.TreeMapMarker
-import org.greenstand.android.TreeTracker.models.Accuracy
 import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.User
-import org.greenstand.android.TreeTracker.models.accuracyStatus
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
 import org.greenstand.android.TreeTracker.utilities.TreeClusterRenderer
 import org.greenstand.android.TreeTracker.utilities.vibrate
@@ -50,7 +44,10 @@ import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
 import timber.log.Timber
 
-class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapReadyCallback,
+class MapsFragment :
+    androidx.fragment.app.Fragment(),
+    OnClickListener,
+    OnMapReadyCallback,
     View.OnLongClickListener {
 
     private val vm: MapViewModel by viewModel()
@@ -61,7 +58,6 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
     private var mapFragment: SupportMapFragment? = null
     private var map: GoogleMap? = null
 
-    private lateinit var fragmentMapGpsAccuracyView: TextView
     private lateinit var convergenceProgressView: Group
     private lateinit var clusterManager: ClusterManager<TreeMapMarker>
 
@@ -74,34 +70,36 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        fragmentMapGpsAccuracyView = view.findViewById(R.id.fragmentMapGpsAccuracy)
         convergenceProgressView = view.findViewById<Group>(R.id.convergenceProgressGroup)
         convergenceProgressView.visibility = View.GONE
 
-        vm.checkInStatusLiveData.observe(this, Observer<Boolean> { planterIsCheckedIn ->
-            if (planterIsCheckedIn) {
-                GlobalScope.launch(Dispatchers.Main) {
+        vm.checkInStatusLiveData.observe(
+            this,
+            Observer<Boolean> { planterIsCheckedIn ->
+                if (planterIsCheckedIn) {
+                    GlobalScope.launch(Dispatchers.Main) {
 
-                    requireActivity().toolbarTitle.text = vm.getPlanterName()
+                        requireActivity().toolbarTitle.text = vm.getPlanterName()
 
-                    val photoPath = user.profilePhotoPath
-                    val profileImageView = mapUserImage
+                        val photoPath = user.profilePhotoPath
+                        val profileImageView = mapUserImage
 
-                    if (photoPath != null) {
-                        val rotatedBitmap =
-                            ImageUtils.decodeBitmap(photoPath, resources.displayMetrics.density)
-                        if (rotatedBitmap != null) {
-                            profileImageView.setImageBitmap(rotatedBitmap)
-                            profileImageView.visibility = View.VISIBLE
+                        if (photoPath != null) {
+                            val rotatedBitmap =
+                                ImageUtils.decodeBitmap(photoPath, resources.displayMetrics.density)
+                            if (rotatedBitmap != null) {
+                                profileImageView.setImageBitmap(rotatedBitmap)
+                                profileImageView.visibility = View.VISIBLE
+                            }
+                        } else {
+                            profileImageView.visibility = View.GONE
                         }
-                    } else {
-                        profileImageView.visibility = View.GONE
                     }
+                } else {
+                    activity!!.toolbarTitle.text = resources.getString(R.string.user_not_identified)
                 }
-            } else {
-                activity!!.toolbarTitle.text = resources.getString(R.string.user_not_identified)
             }
-        })
+        )
 
         if (mapFragment == null) {
             mapFragment = SupportMapFragment()
@@ -110,10 +108,6 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
                 commit()
             }
         }
-
-        vm.locationUpdates.observe(this, Observer {
-            updateLocationAccuracy(it)
-        })
 
         if (!(activity as AppCompatActivity).supportActionBar!!.isShowing) {
             Timber.d("toolbar hide")
@@ -133,51 +127,27 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
         mapFragment!!.getMapAsync(this)
     }
 
-    private fun updateLocationAccuracy(location: Location?) {
-        when (location.accuracyStatus()) {
-            Accuracy.GOOD -> {
-                fragmentMapGpsAccuracyView.setTextColor(Color.GREEN)
-                fragmentMapGpsAccuracyView.text =
-                    getString(R.string.gps_accuracy_double_colon, location!!.accuracy.roundToInt())
-            }
-            Accuracy.BAD -> {
-                fragmentMapGpsAccuracyView.setTextColor(Color.RED)
-                fragmentMapGpsAccuracyView.text =
-                    getString(R.string.gps_accuracy_double_colon, location!!.accuracy.roundToInt())
-            }
-            Accuracy.NONE -> {
-                fragmentMapGpsAccuracyView.setTextColor(Color.RED)
-                fragmentMapGpsAccuracyView.text = getString(R.string.gps_accuracy) + " N/A"
-            }
-        }
-    }
-
     override fun onClick(v: View) {
         v.vibrate()
         when (v.id) {
             R.id.addTreeButton -> {
                 Timber.d("fab click")
-                if (locationUpdateManager.hasSufficientAccuracy() ||
-                    !FeatureFlags.HIGH_GPS_ACCURACY) {
-                    // Disable the addTreeButton below to avoid triggering the onClick listener
-                    // more than one once.
-                    addTreeButton.isEnabled = false
-                    lifecycleScope.launch {
-                        if (vm.requiresLogin()) {
-                            findNavController().navigate(
-                                MapsFragmentDirections.actionGlobalLoginFlowGraph())
-                        } else {
-                            vm.turnOnTreeCaptureMode()
-                            convergenceProgressView.visibility = View.VISIBLE
-                            vm.resolveLocationConvergence()
-                            convergenceProgressView.visibility = View.GONE
-                            findNavController()
-                                .navigate(MapsFragmentDirections.actionMapsFragmentToNewTreeGraph())
-                        }
+                // Disable the addTreeButton below to avoid triggering the onClick listener
+                // more than one once.
+                addTreeButton.isEnabled = false
+                lifecycleScope.launch {
+                    if (vm.requiresLogin()) {
+                        findNavController().navigate(
+                            MapsFragmentDirections.actionGlobalLoginFlowGraph()
+                        )
+                    } else {
+                        vm.turnOnTreeCaptureMode()
+                        convergenceProgressView.visibility = View.VISIBLE
+                        vm.resolveLocationConvergence()
+                        convergenceProgressView.visibility = View.GONE
+                        findNavController()
+                            .navigate(MapsFragmentDirections.actionMapsFragmentToNewTreeGraph())
                     }
-                } else {
-                    Toast.makeText(activity, "Insufficient GPS accuracy.", Toast.LENGTH_SHORT)
-                        .show()
                 }
             }
             R.id.goToUploadsButton -> {
@@ -241,9 +211,9 @@ class MapsFragment : androidx.fragment.app.Fragment(), OnClickListener, OnMapRea
 
         if (ActivityCompat.checkSelfPermission(context!!, Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
-                context!!,
-                Manifest.permission.ACCESS_COARSE_LOCATION
-            ) != PackageManager.PERMISSION_GRANTED
+                    context!!,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+                ) != PackageManager.PERMISSION_GRANTED
         ) {
             // TODO: Consider calling
             //    ActivityCompat#requestPermissions

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/FeatureFlags.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/FeatureFlags.kt
@@ -3,12 +3,15 @@ package org.greenstand.android.TreeTracker.models
 import org.greenstand.android.TreeTracker.BuildConfig
 
 object FeatureFlags {
-    val DEBUG_ENABLED: Boolean = BuildConfig.BUILD_TYPE == "dev" || BuildConfig.BUILD_TYPE == "debug" || BuildConfig.BUILD_TYPE == "acceleration"
+    val DEBUG_ENABLED: Boolean = (
+        BuildConfig.BUILD_TYPE == "dev" ||
+            BuildConfig.BUILD_TYPE == "debug" ||
+            BuildConfig.BUILD_TYPE == "acceleration"
+        )
     val TREE_HEIGHT_FEATURE_ENABLED: Boolean = BuildConfig.TREE_HEIGHT_FEATURE_ENABLED
     val TREE_NOTE_FEATURE_ENABLED: Boolean = BuildConfig.TREE_NOTE_FEATURE_ENABLED
     val TREE_DBH_FEATURE_ENABLED: Boolean = BuildConfig.TREE_DBH_FEATURE_ENABLED
     val FABRIC_ENABLED: Boolean = BuildConfig.ENABLE_FABRIC
-    val HIGH_GPS_ACCURACY: Boolean = BuildConfig.GPS_ACCURACY
     val AUTOMATIC_SIGN_OUT_FEATURE_ENABLED: Boolean = BuildConfig.AUTOMATIC_SIGN_OUT_FEATURE_ENABLED
     val BLUR_DETECTION_ENABLED: Boolean = BuildConfig.BLUR_DETECTION_ENABLED
     val ORG_LINK_ENABLED: Boolean = BuildConfig.ORG_LINK

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/Locations.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.database.entity.LocationDataEntity
-import org.greenstand.android.TreeTracker.utilities.ValueHelper
 import timber.log.Timber
 
 class LocationUpdateManager(
@@ -117,12 +116,6 @@ class LocationUpdateManager(
         return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
     }
 
-    fun hasSufficientAccuracy(): Boolean {
-        return currentLocation?.let {
-            it.hasAccuracy() && it.accuracy < ValueHelper.MIN_ACCURACY_DEFAULT_SETTING
-        } ?: false
-    }
-
     private fun hasLocationPermissions(): Boolean {
         val fineLocationPermission = ContextCompat.checkSelfPermission(
             context,
@@ -143,17 +136,6 @@ enum class Accuracy {
     GOOD,
     BAD,
     NONE
-}
-
-fun Location?.accuracyStatus(): Accuracy {
-    if (this == null || !hasAccuracy()) {
-        return Accuracy.NONE
-    }
-    return if (accuracy < ValueHelper.MIN_ACCURACY_DEFAULT_SETTING) {
-        Accuracy.GOOD
-    } else {
-        Accuracy.BAD
-    }
 }
 
 class LocationDataCapturer(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateFakeTreesUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateFakeTreesUseCase.kt
@@ -2,7 +2,6 @@ package org.greenstand.android.TreeTracker.usecases
 
 import android.content.Context
 import java.util.UUID
-import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.Tree
 import org.greenstand.android.TreeTracker.models.User
@@ -18,7 +17,7 @@ class CreateFakeTreesUseCase(
 ) : UseCase<CreateFakeTreesParams, Unit>() {
 
     override suspend fun execute(params: CreateFakeTreesParams) {
-        if (locationUpdateManager.currentLocation == null && FeatureFlags.HIGH_GPS_ACCURACY) {
+        if (locationUpdateManager.currentLocation == null) {
             return
         }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ValueHelper.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ValueHelper.kt
@@ -13,7 +13,5 @@ object ValueHelper {
 
     const val TAKEN_IMAGE_PATH = "TAKEN_IMAGE_PATH"
 
-    const val MIN_ACCURACY_DEFAULT_SETTING = 10
-
     const val FOCUS_METRIC_VALUE = "FOCUS_METRIC_VALUE"
 }

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -50,7 +50,7 @@
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:indeterminate="true"
-        app:layout_constraintBottom_toTopOf="@+id/fragmentMapGpsAccuracy"
+        app:layout_constraintBottom_toBottomOf="@+id/map"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -71,29 +71,18 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:foregroundGravity="center"
-        app:constraint_referenced_ids="convergenceProgressBar, convergenceProgressText"/>
-
-    <TextView
-        android:id="@+id/fragmentMapGpsAccuracy"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        android:text="@string/gps_accuracy_double_colon"
-        android:textColor="@color/red"
-        android:textSize="@dimen/text_size_twenty" />
+        app:constraint_referenced_ids="convergenceProgressBar, convergenceProgressText" />
 
     <Button
         android:id="@+id/addTreeButton"
+        style="@style/NewButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/activity_horizontal_margin"
         android:padding="@dimen/padding_five"
         android:text="@string/add_tree"
-        style="@style/NewButtonStyle"
-        app:layout_constraintBottom_toTopOf="@+id/fragmentMapGpsAccuracy"
+        app:layout_constraintBottom_toBottomOf="@+id/map"
         app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Now that we use threshold value for variance of contiguous location data stream to determine when it is fine to proceed with adding a tree (enabling the camera to take a picture), we don't need to use accuracy also. This code was left in prior updates that introduced variance of location data. This PR is clean up to remove those references in map fragment.