### PR TITLE
Associate mean longitude and latitude from convergence with tree capture record

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
@@ -69,7 +69,7 @@ val appModule = module {
 
     viewModel { TreePreviewViewModel(get(), get()) }
 
-    viewModel { NewTreeViewModel(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { NewTreeViewModel(get(), get(), get(), get(), get(), get()) }
 
     viewModel { ConfigViewModel(get(), get()) }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/NewTreeFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/NewTreeFragment.kt
@@ -73,14 +73,6 @@ class NewTreeFragment :
             fragmentNewTreeSave.text = getString(R.string.save)
         }
 
-        vm.accuracyLiveData.observe(
-            this,
-            Observer {
-                fragmentNewTreeGpsAccuracy.text = fragmentNewTreeGpsAccuracy
-                    .context.getString(R.string.gps_accuracy_double_colon, it)
-            }
-        )
-
         vm.navigateBack.observe(
             this,
             Observer {
@@ -95,13 +87,6 @@ class NewTreeFragment :
                 findNavController().navigate(
                     NewTreeFragmentDirections.actionNewTreeFragmentToTreeHeightFragment(it)
                 )
-            }
-        )
-
-        vm.onInsufficientGps.observe(
-            this,
-            Observer {
-                CustomToast.showToast("Insufficient GPS accuracy")
             }
         )
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/TreePreviewFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/TreePreviewFragment.kt
@@ -10,13 +10,17 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.navArgs
-import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.fragment_tree_preview.*
+import java.util.Date
+import kotlinx.android.synthetic.main.activity_main.toolbarTitle
+import kotlinx.android.synthetic.main.fragment_tree_preview.fragmentTreePreviewCreated
+import kotlinx.android.synthetic.main.fragment_tree_preview.fragmentTreePreviewDistance
+import kotlinx.android.synthetic.main.fragment_tree_preview.fragmentTreePreviewImage
+import kotlinx.android.synthetic.main.fragment_tree_preview.fragmentTreePreviewNoImage
+import kotlinx.android.synthetic.main.fragment_tree_preview.fragmentTreePreviewNotes
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
 import org.greenstand.android.TreeTracker.viewmodels.TreePreviewViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
-import java.util.*
 
 class TreePreviewFragment : Fragment() {
 
@@ -33,7 +37,11 @@ class TreePreviewFragment : Fragment() {
     }
 
     @SuppressLint("SimpleDateFormat")
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         return inflater.inflate(R.layout.fragment_tree_preview, container, false)
     }
 
@@ -47,7 +55,9 @@ class TreePreviewFragment : Fragment() {
             val treeData = vm.loadTree(args.treeId.toLong())
 
             if (treeData.localPhotoPath != null) {
-                val bitmap = ImageUtils.decodeBitmap(treeData.localPhotoPath, resources.displayMetrics.density)
+                val bitmap = ImageUtils.decodeBitmap(
+                    treeData.localPhotoPath, resources.displayMetrics.density
+                )
                 fragmentTreePreviewImage.setImageBitmap(bitmap)
                 fragmentTreePreviewImage.visibility = View.VISIBLE
                 fragmentTreePreviewNoImage.visibility = View.INVISIBLE
@@ -55,8 +65,8 @@ class TreePreviewFragment : Fragment() {
                 fragmentTreePreviewNoImage.visibility = View.VISIBLE
             }
 
-            fragmentTreePreviewDistance.text = "${treeData.distance.toInt()} ${resources.getString(R.string.meters)}"
-            fragmentTreePreviewGpsAccuracy.text = "${treeData.accuracy} ${resources.getString(R.string.meters)}"
+            fragmentTreePreviewDistance.text = "${treeData.distance.toInt()} " +
+                "${resources.getString(R.string.meters)}"
             fragmentTreePreviewCreated.text = Date(treeData.createdAt).toLocaleString()
             fragmentTreePreviewNotes.text = treeData.note
         }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/Tree.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/Tree.kt
@@ -10,6 +10,8 @@ class Tree(
     val planterCheckInId: Long,
     val content: String,
     val photoPath: String,
+    val meanLongitude: Double,
+    val meanLatitude: Double,
     private val treeAttributes: MutableMap<String, String> = mutableMapOf()
 ) : Parcelable {
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateFakeTreesUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateFakeTreesUseCase.kt
@@ -30,7 +30,9 @@ class CreateFakeTreesUseCase(
                 planterCheckInId = user.planterCheckinId!!,
                 photoPath = file.absolutePath,
                 content = "My Note",
-                treeUuid = UUID.randomUUID()
+                treeUuid = UUID.randomUUID(),
+                meanLongitude = 0.0,
+                meanLatitude = 0.0
             )
 
             createTreeUseCase.execute(tree)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateTreeUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateTreeUseCase.kt
@@ -16,24 +16,24 @@ class CreateTreeUseCase(
     private val analytics: Analytics
 ) : UseCase<Tree, Long>() {
 
-    override suspend fun execute(tree: Tree): Long = withContext(Dispatchers.IO) {
+    override suspend fun execute(params: Tree): Long = withContext(Dispatchers.IO) {
         val location = locationUpdateManager.currentLocation
         val time = location?.time ?: System.currentTimeMillis()
         val timeInSeconds = time / 1000
 
         val entity = TreeCaptureEntity(
-            uuid = tree.treeUuid.toString(),
-            planterCheckInId = tree.planterCheckInId,
-            localPhotoPath = tree.photoPath,
+            uuid = params.treeUuid.toString(),
+            planterCheckInId = params.planterCheckInId,
+            localPhotoPath = params.photoPath,
             photoUrl = null,
-            noteContent = tree.content,
-            longitude = location?.longitude ?: 0.0,
-            latitude = location?.latitude ?: 0.0,
+            noteContent = params.content,
+            longitude = params.meanLongitude,
+            latitude = params.meanLatitude,
             accuracy = location?.accuracy?.toDouble() ?: 10000.0,
             createAt = timeInSeconds
         )
         analytics.treePlanted()
-        val attributeEntitites = tree.treeCaptureAttributes().map {
+        val attributeEntitites = params.treeCaptureAttributes().map {
             TreeAttributeEntity(it.key, it.value, -1)
         }.toList()
         Timber.d("Inserting TreeCapture entity $entity")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateTreeUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateTreeUseCase.kt
@@ -29,7 +29,7 @@ class CreateTreeUseCase(
             noteContent = params.content,
             longitude = params.meanLongitude,
             latitude = params.meanLatitude,
-            accuracy = location?.accuracy?.toDouble() ?: 10000.0,
+            accuracy = 0.0, // accuracy is a legacy remnant and not used. Pending table cleanup
             createAt = timeInSeconds
         )
         analytics.treePlanted()

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/NewTreeViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/NewTreeViewModel.kt
@@ -9,7 +9,6 @@ import org.greenstand.android.TreeTracker.models.Convergence
 import org.greenstand.android.TreeTracker.models.DeviceOrientation
 import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
-import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.StepCounter
 import org.greenstand.android.TreeTracker.models.Tree
 import org.greenstand.android.TreeTracker.models.User
@@ -18,7 +17,6 @@ import org.greenstand.android.TreeTracker.utilities.ValueHelper
 
 class NewTreeViewModel(
     private val user: User,
-    private val locationUpdateManager: LocationUpdateManager,
     private val locationDataCapturer: LocationDataCapturer,
     private val createTreeUseCase: CreateTreeUseCase,
     private val analytics: Analytics,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/TreePreviewViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/TreePreviewViewModel.kt
@@ -32,7 +32,6 @@ class TreePreviewViewModel(
             localPhotoPath = tree.localPhotoPath,
             imageUrl = tree.photoUrl,
             distance = results.first(),
-            accuracy = tree.accuracy.toFloat(),
             createdAt = tree.createAt,
             note = tree.noteContent
         )
@@ -43,7 +42,6 @@ data class TreePreviewData(
     val localPhotoPath: String?,
     val imageUrl: String?,
     val distance: Float,
-    val accuracy: Float,
     val createdAt: Long,
     val note: String
 )

--- a/app/src/main/res/layout/fragment_new_tree.xml
+++ b/app/src/main/res/layout/fragment_new_tree.xml
@@ -42,24 +42,11 @@
 
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/fragmentNewTreeGpsAccuracy"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/fragment_new_tree_focus_warning_layout"
-        android:paddingLeft="@dimen/margin_twenty_four"
-        android:paddingRight="@dimen/margin_twenty_four"
-        android:paddingTop="@dimen/one_dp"
-        android:gravity="center"
-        android:text="@string/gps_accuracy_double_colon"
-        android:textColor="@color/black"
-        android:textSize="@dimen/text_size_seventeen"/>
-
     <EditText
         android:id="@+id/fragmentNewTreeNote"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/fragmentNewTreeGpsAccuracy"
+        android:layout_below="@+id/fragment_new_tree_focus_warning_layout"
         android:layout_marginLeft="@dimen/margin_twenty_four"
         android:layout_marginRight="@dimen/margin_twenty_four"
         android:layout_marginTop="16dp"

--- a/app/src/main/res/layout/fragment_tree_preview.xml
+++ b/app/src/main/res/layout/fragment_tree_preview.xml
@@ -60,40 +60,6 @@
             </LinearLayout>
 
             <LinearLayout
-                    android:id="@+id/fragment_tree_preview_gps_accuracy_layout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/fragment_tree_preview_distance_layout"
-                    android:orientation="horizontal"
-                    android:paddingLeft="@dimen/margin_twenty_four"
-                    android:paddingTop="@dimen/three_dp"
-                    android:paddingRight="@dimen/margin_twenty_four">
-
-                <TextView
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_twelve"
-                        android:layout_weight="1"
-                        android:text="@string/gps_accuracy"
-                        android:textColor="@color/black"
-                        android:textSize="@dimen/text_size_seventeen"/>
-
-                <TextView
-                        android:id="@+id/fragmentTreePreviewGpsAccuracy"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_twelve"
-                        android:layout_weight="1"
-                        android:gravity="end"
-                        android:text="@string/five_text_view"
-                        android:textColor="@color/black"
-                        android:textSize="@dimen/text_size_seventeen"/>
-
-            </LinearLayout>
-
-
-
-            <LinearLayout
                     android:id="@+id/fragment_tree_preview_created_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/test/java/org/greenstand/android/TreeTracker/models/LocationDataCapturerTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/models/LocationDataCapturerTest.kt
@@ -81,7 +81,7 @@ class LocationDataCapturerTest {
 
         locationDataCapturer.turnOffTreeCaptureMode()
 
-        assertNull("Convergence is reset to null", locationDataCapturer.convergence)
+        assertNull("Convergence is reset to null", locationDataCapturer.lastConvergenceWithinRange)
         assertNull("Tree UUID is reset to null", locationDataCapturer.generatedTreeUuid)
     }
 
@@ -127,6 +127,7 @@ class LocationDataCapturerTest {
             locationsLiveData.postValue(location)
         }
         assertTrue(locationDataCapturer.isConvergenceWithinRange())
+        assertNotNull(locationDataCapturer.lastConvergenceWithinRange)
     }
 
     // Hard coded longitude and latitude pair values
@@ -153,6 +154,7 @@ class LocationDataCapturerTest {
         }
 
         assertFalse(locationDataCapturer.isConvergenceWithinRange())
+        assertNull(locationDataCapturer.lastConvergenceWithinRange)
     }
 
     val locationsWithLowAndHighVariance = listOf(


### PR DESCRIPTION
Associate mean longitude and latitude values obtained from convergence with tree capture record instead of the current way of associating long/lat values from the location data from location update manager. The convergence data is derived from more than one converged gps location data compared to long/lat values from one gps location data (a point in time value). This change uses a mean longitude/latitude value by averaging 5 converged location data points.