### PR TITLE
Make the URLs on the about page function as links

### DIFF
--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -44,6 +44,7 @@
         android:layout_marginLeft="@dimen/margin_twenty_four"
         android:layout_marginTop="@dimen/margin_twelve"
         android:layout_marginRight="@dimen/margin_twenty_four"
+        android:autoLink="email|web"
         android:text="@string/information_text"
         android:textColor="@color/black"
         android:textSize="@dimen/about_text_size" />


### PR DESCRIPTION
Make the URLs and email info clickable in the about page in treetracker app.