### PR TITLE
Back key on tree height fragment to restart the tree capture flow

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/TreeHeightFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/TreeHeightFragment.kt
@@ -5,10 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.addCallback
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -18,20 +18,21 @@ import kotlinx.android.synthetic.main.fragment_tree_height.*
 import kotlinx.android.synthetic.main.fragment_tree_height.view.*
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.data.TreeColor
-import org.greenstand.android.TreeTracker.utilities.ValueHelper
 import org.greenstand.android.TreeTracker.utilities.animateColor
 import org.greenstand.android.TreeTracker.utilities.color
 import org.greenstand.android.TreeTracker.viewmodels.TreeHeightViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
-
 
 class TreeHeightFragment : Fragment() {
     private val vm: TreeHeightViewModel by viewModel()
     private val args: TreeHeightFragmentArgs by navArgs()
     private var isInitialState = true
 
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         return inflater.inflate(R.layout.fragment_tree_height, container, false)
     }
 
@@ -43,11 +44,13 @@ class TreeHeightFragment : Fragment() {
 
         vm.newTree = args.newTree
 
-        listOf(height_button_five,
-               height_button_four,
-               height_button_three,
-               height_button_two,
-               height_button_one)
+        listOf(
+            height_button_five,
+            height_button_four,
+            height_button_three,
+            height_button_two,
+            height_button_one
+        )
             .forEachIndexed { index, colorView ->
                 colorView.setOnClickListener {
                     moveSelection(parentView, colorView, index)
@@ -59,22 +62,35 @@ class TreeHeightFragment : Fragment() {
             vm.saveNewTree()
         }
 
-        vm.toastMessagesLiveData().observe(this, Observer {
-            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
-        })
+        vm.toastMessagesLiveData().observe(
+            this,
+            Observer {
+                Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            }
+        )
 
-        vm.onFinishedLiveData().observe(this, Observer {
+        vm.onFinishedLiveData().observe(
+            this,
+            Observer {
+                findNavController().popBackStack(R.id.mapsFragment, false)
+            }
+        )
+
+        vm.onEnableButtonLiveData().observe(
+            this,
+            Observer {
+                save_tree_height.isEnabled = it
+            }
+        )
+
+        requireActivity().onBackPressedDispatcher.addCallback(this) {
+            vm.cancelTreeCapture()
             findNavController().popBackStack(R.id.mapsFragment, false)
-            fragmentManager?.popBackStack(ValueHelper.NEW_TREE_FRAGMENT, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        })
-
-        vm.onEnableButtonLiveData().observe(this, Observer {
-            save_tree_height.isEnabled = it
-        })
+        }
     }
 
     private fun indexToBias(index: Int): Float {
-        return when(index) {
+        return when (index) {
             0 -> .025f
             1 -> .275f
             2 -> .5f
@@ -85,7 +101,7 @@ class TreeHeightFragment : Fragment() {
     }
 
     private fun indexToTreeColor(index: Int): TreeColor {
-        return when(index) {
+        return when (index) {
             0 -> TreeColor.GREEN
             1 -> TreeColor.PURPLE
             2 -> TreeColor.YELLOW
@@ -118,12 +134,12 @@ class TreeHeightFragment : Fragment() {
                     floating_button_inner.animateColor(toColor = colorView.color)
                     applyTo(view)
                 }
-
             }
         }
 
         if (isInitialState) {
-            // move view to position of tapped color, size it, color it, make visible all without animations
+            // move view to position of tapped color, size it, color it, make visible all
+            // without animations
             view.post {
 
                 val bias = indexToBias(index)
@@ -133,8 +149,14 @@ class TreeHeightFragment : Fragment() {
 
                 ConstraintSet().apply {
                     clone(view)
-                    connect(R.id.floating_button, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP, 32)
-                    connect(R.id.floating_button, ConstraintSet.BOTTOM, R.id.save_tree_height, ConstraintSet.TOP, 32)
+                    connect(
+                        R.id.floating_button, ConstraintSet.TOP, ConstraintSet.PARENT_ID,
+                        ConstraintSet.TOP, 32
+                    )
+                    connect(
+                        R.id.floating_button, ConstraintSet.BOTTOM, R.id.save_tree_height,
+                        ConstraintSet.TOP, 32
+                    )
                     centerHorizontally(R.id.floating_button, ConstraintSet.PARENT_ID)
                     setVerticalBias(R.id.floating_button, bias)
                     constrainHeight(R.id.floating_button, height)
@@ -151,6 +173,4 @@ class TreeHeightFragment : Fragment() {
             animatedUpdate(view, index)
         }
     }
-
 }
-

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ValueHelper.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ValueHelper.kt
@@ -2,8 +2,6 @@ package org.greenstand.android.TreeTracker.utilities
 
 object ValueHelper {
 
-    const val NEW_TREE_FRAGMENT = "NEW_TREE_FRAGMENT"
-
     const val INTENT_CAMERA = 1001
 
     const val JPEG_FILE_PREFIX = "IMG_"

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/MapViewModel.kt
@@ -5,11 +5,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import org.greenstand.android.TreeTracker.models.DeviceOrientation
+import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.StepCounter
 import org.greenstand.android.TreeTracker.models.User
-import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesParams
 import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesUseCase
 import org.greenstand.android.TreeTracker.usecases.ValidateCheckInStatusUseCase
@@ -54,11 +54,10 @@ class MapViewModel constructor(
     }
 
     fun turnOnTreeCaptureMode() {
+        deviceOrientation.enable()
         if (FeatureFlags.TREE_DBH_FEATURE_ENABLED) return
-
         locationDataCapturer.turnOnTreeCaptureMode()
         stepCounter.enable()
-        deviceOrientation.enable()
     }
 
     suspend fun resolveLocationConvergence() {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/NewTreeViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/NewTreeViewModel.kt
@@ -97,7 +97,6 @@ class NewTreeViewModel(
     }
 
     suspend fun waitForConvergence() {
-        deviceOrientation.enable()
         stepCounter.enable()
         locationDataCapturer.turnOnTreeCaptureMode()
         locationDataCapturer.converge()

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/TreeHeightViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodels/TreeHeightViewModel.kt
@@ -46,13 +46,17 @@ class TreeHeightViewModel(
                     withContext(Dispatchers.IO) {
                         with(TreeHeightAttributes(heightColor = treeColor!!)) {
                             tree.addTreeAttribute(
-                                Tree.Attributes.TREE_COLOR_ATTR_KEY, heightColor.value)
+                                Tree.Attributes.TREE_COLOR_ATTR_KEY, heightColor.value
+                            )
                             tree.addTreeAttribute(
-                                Tree.Attributes.APP_BUILD_ATTR_KEY, appBuild)
+                                Tree.Attributes.APP_BUILD_ATTR_KEY, appBuild
+                            )
                             tree.addTreeAttribute(
-                                Tree.Attributes.APP_FLAVOR_ATTR_KEY, appFlavor)
+                                Tree.Attributes.APP_FLAVOR_ATTR_KEY, appFlavor
+                            )
                             tree.addTreeAttribute(
-                                Tree.Attributes.APP_VERSION_ATTR_KEY, appVersion)
+                                Tree.Attributes.APP_VERSION_ATTR_KEY, appVersion
+                            )
                         }
                         createTreeUseCase.execute(tree)
                     }
@@ -68,6 +72,10 @@ class TreeHeightViewModel(
                 }
                 ?: run { toastMessageLiveData.postValue(R.string.tree_height_save_error) }
         }
+    }
+
+    fun cancelTreeCapture() {
+        stepCounter.disable()
     }
 
     fun toastMessagesLiveData(): LiveData<Int> = toastMessageLiveData


### PR DESCRIPTION
This change fixes the error when back key is pressed when the user is at the tree height fragment screen.
The error behavior is documented here  https://github.com/Greenstand/treetracker-android/issues/548.

The standard navigation backstack pop takes the screen to the camera view instead of the New tree fragment.
This is probably due to the programmatic navigation to the camera view when new tree fragment is loaded.
User proceeding from that points throws a navigation error since the navgraph doesn't have the ImageCaptureActivity in its
design.

Given the existing design, and the states involved in new tree fragment (tree_uuid, location, step count data), the reliable
fix for the upcoming release would take the user to the map screen if user presses the back navigation. This way the app crash
is prevented while making sure the data integrity is maintained.

