### PR TITLE
Fix for planter registrations failing to be uploaded to s3

### DIFF
--- a/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/7.json
+++ b/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/7.json
@@ -1,0 +1,430 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 7,
+    "identityHash": "e3f96404ac712f0618eaf04e8251407d",
+    "entities": [
+      {
+        "tableName": "planter_check_in",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planter_info_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `created_at` INTEGER NOT NULL, FOREIGN KEY(`planter_info_id`) REFERENCES `planter_info`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planterInfoId",
+            "columnName": "planter_info_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_planter_check_in_planter_info_id",
+            "unique": false,
+            "columnNames": [
+              "planter_info_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_check_in_planter_info_id` ON `${TABLE_NAME}` (`planter_info_id`)"
+          },
+          {
+            "name": "index_planter_check_in_local_photo_path",
+            "unique": false,
+            "columnNames": [
+              "local_photo_path"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_check_in_local_photo_path` ON `${TABLE_NAME}` (`local_photo_path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "planter_info",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_info_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "planter_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `planter_identifier` TEXT NOT NULL, `first_name` TEXT NOT NULL, `last_name` TEXT NOT NULL, `organization` TEXT, `phone` TEXT, `email` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, `record_uuid` TEXT NOT NULL DEFAULT '')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier",
+            "columnName": "planter_identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recordUuid",
+            "columnName": "record_uuid",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_planter_info_planter_identifier",
+            "unique": false,
+            "columnNames": [
+              "planter_identifier"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_info_planter_identifier` ON `${TABLE_NAME}` (`planter_identifier`)"
+          },
+          {
+            "name": "index_planter_info_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_info_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tree_attribute",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, `tree_capture_id` INTEGER NOT NULL, FOREIGN KEY(`tree_capture_id`) REFERENCES `tree_capture`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeCaptureId",
+            "columnName": "tree_capture_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_attribute_tree_capture_id",
+            "unique": false,
+            "columnNames": [
+              "tree_capture_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_attribute_tree_capture_id` ON `${TABLE_NAME}` (`tree_capture_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tree_capture",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tree_capture_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tree_capture",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uuid` TEXT NOT NULL, `planter_checkin_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `note_content` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `accuracy` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, FOREIGN KEY(`planter_checkin_id`) REFERENCES `planter_check_in`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planterCheckInId",
+            "columnName": "planter_checkin_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noteContent",
+            "columnName": "note_content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_capture_planter_checkin_id",
+            "unique": false,
+            "columnNames": [
+              "planter_checkin_id"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_planter_checkin_id` ON `${TABLE_NAME}` (`planter_checkin_id`)"
+          },
+          {
+            "name": "index_tree_capture_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "planter_check_in",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_checkin_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "location_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `json_value` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locationDataJson",
+            "columnName": "json_value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_location_data_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_data_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e3f96404ac712f0618eaf04e8251407d')"
+    ]
+  }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
@@ -18,7 +18,7 @@ import org.greenstand.android.TreeTracker.database.entity.TreeCaptureEntity
         TreeCaptureEntity::class,
         LocationDataEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -32,14 +32,16 @@ abstract class AppDatabase : RoomDatabase() {
         fun getInstance(context: Context): AppDatabase {
             if (INSTANCE == null) {
                 synchronized(AppDatabase::class) {
-                    INSTANCE = Room.databaseBuilder(context.applicationContext,
-                                                    AppDatabase::class.java,
-                                                    DB_NAME
+                    INSTANCE = Room.databaseBuilder(
+                        context.applicationContext,
+                        AppDatabase::class.java,
+                        DB_NAME
                     )
                         .addMigrations(
                             MIGRATION_3_4,
                             MIGRATION_4_5,
-                            MIGRATION_5_6
+                            MIGRATION_5_6,
+                            MIGRATION_6_7
                         )
                         .build()
                 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/Migrations.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/Migrations.kt
@@ -4,6 +4,16 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.greenstand.android.TreeTracker.database.entity.PlanterInfoEntity
 
+val MIGRATION_6_7 = object : Migration(6, 7) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        val sql = """CREATE INDEX `index_planter_check_in_local_photo_path`
+                    | ON `planter_check_in` (`local_photo_path`)
+                    | """.trimMargin()
+        database.execSQL(sql)
+    }
+}
+
 val MIGRATION_5_6 = object : Migration(5, 6) {
 
     override fun migrate(database: SupportSQLiteDatabase) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
@@ -45,8 +45,8 @@ interface TreeTrackerDAO {
     fun updatePlanterInfoUploadStatus(ids: List<Long>, isUploaded: Boolean)
 
     @Transaction
-    @Query("SELECT * FROM planter_check_in WHERE photo_url IS null AND planter_info_id = :planterInfoId") // kt-lint-disable max-line-length
-    fun getPlanterCheckInsToUpload(planterInfoId: Long): List<PlanterCheckInEntity>
+    @Query("SELECT * FROM planter_check_in WHERE local_photo_path IS NOT NULL")
+    fun getPlanterCheckInsToUpload(): List<PlanterCheckInEntity>
 
     @Transaction
     @Query("SELECT * FROM planter_check_in WHERE _id IN (:planterCheckInIds)")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/PlanterCheckInEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/PlanterCheckInEntity.kt
@@ -19,7 +19,7 @@ import androidx.room.PrimaryKey
 data class PlanterCheckInEntity(
     @ColumnInfo(name = PLANTER_INFO_ID, index = true)
     var planterInfoId: Long,
-    @ColumnInfo(name = LOCAL_PHOTO_PATH)
+    @ColumnInfo(name = LOCAL_PHOTO_PATH, index = true)
     var localPhotoPath: String?,
     @ColumnInfo(name = PHOTO_URL)
     var photoUrl: String?,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/DeleteOldPlanterImagesUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/DeleteOldPlanterImagesUseCase.kt
@@ -11,11 +11,14 @@ class DeleteOldPlanterImagesUseCase(
 
     override suspend fun execute(params: Unit) {
 
-        val planterCheckIns = dao.getAllPlanterCheckIn()
+        val planterCheckIns = dao.getPlanterCheckInsToUpload()
 
         // Delete all local image files for registrations except for the currently logged in users photo...
         val loggedOutPlanterCheckIns = planterCheckIns
-            .filter { it.id != user.planterCheckinId }
+            .filter {
+                it.id != user.planterCheckinId &&
+                    it.localPhotoPath != null && it.photoUrl != null
+            }
             .sortedBy { it.createdAt }
 
         loggedOutPlanterCheckIns.forEach {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadPlanterInfoUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadPlanterInfoUseCase.kt
@@ -48,7 +48,7 @@ class UploadPlanterInfoUseCase(
         val jsonBundle = gson.toJson(UploadBundle(registrations = registrationRequests))
 
         // Create a hash ID to reference this upload bundle later
-        val bundleId = jsonBundle.md5()
+        val bundleId = jsonBundle.md5() + "_registrations"
 
         val planterInfoIds = planterInfoList.map { it.id }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadPlanterUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadPlanterUseCase.kt
@@ -23,15 +23,17 @@ class UploadPlanterUseCase(
     override suspend fun execute(params: UploadPlanterParams) = withContext(Dispatchers.IO) {
         params.planterInfoIds
 
-        // Upload all the images
-        val planterCheckIns = dao.getPlanterCheckInsById(params.planterInfoIds)
-        uploadPlanterCheckInUseCase.execute(
-            UploadPlanterCheckInParams(planterCheckIns.map { it.id }))
-
         // Upload the user data
         val planterInfoList = params.planterInfoIds.mapNotNull { dao.getPlanterInfoById(it) }
         uploadPlanterInfoUseCase.execute(
-            UploadPlanterInfoParams(planterInfoIds = planterInfoList.map { it.id }))
+            UploadPlanterInfoParams(planterInfoIds = planterInfoList.map { it.id })
+        )
+
+        // Upload all the images
+        val planterCheckIns = dao.getPlanterCheckInsToUpload()
+        uploadPlanterCheckInUseCase.execute(
+            UploadPlanterCheckInParams(planterCheckIns.map { it.id })
+        )
 
         // Delete local images
         deleteOldPlanterImagesUseCase.execute(Unit)


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/Greenstand/treetracker-android/issues/554 along with one other issue discovered while debugging the reported issue.

1. The local_photo_path value in planter_check_in entity were nullified eagerly regardless of whether they are uploaded to the s3 bucket or not in `DeleteOldPlanterImagesUseCase.kt`.  This had a effect when syncing a bunch of registrations on a slow network   while the planter switches to register a new user.  The update_planters job when entering the delete old planter images routine, fetches all the checkin records (including the new user) to purge the photos without considering if the photo is uploaded to s3. This on a subsequent sync for the new planter registered throws a null pointer error while processing planter checkin thereby failing the registration upload.

 The fix moved is to move the registration sync to happen first along with adding filters to only consider purging local images of planters who have their images sycned to s3 in the checkin/deletion process.

2. Repeated planter check-ins were left unprocessed i.e. images/locations were not uploaded and were left unprocessed in the db. Only the very first check-in on registration was processed. The fix is to use an appropriate query to fetch the correct set of planter checkins (required an index to be added to planter_checkin entity).
