### PR TITLE
Make pressing enter on keyboard go to next screen

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/LoginFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/LoginFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -61,6 +62,13 @@ class LoginFragment : Fragment() {
 
         loginPhoneEditText.onTextChanged { vm.updatePhone(it) }
         loginEmailEditText.onTextChanged { vm.updateEmail(it) }
+        loginEmailEditText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_GO && login_button.isEnabled) {
+                login_button.performClick()
+                true
+            }
+            false
+        }
 
         login_button.setOnClickListener {
             GlobalScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/fragments/SignUpFragment.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/fragments/SignUpFragment.kt
@@ -4,10 +4,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.fragment_login.*
 import kotlinx.android.synthetic.main.fragment_signup.*
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.analytics.Analytics
@@ -45,6 +47,14 @@ class SignUpFragment : Fragment() {
         signupFirstNameEditText.onTextChanged { vm.firstName = it }
         signupLastNameEditText.onTextChanged { vm.lastName = it }
         signupOrganizationEditText.onTextChanged { vm.organization = it }
+        signupOrganizationEditText.setOnEditorActionListener { _, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_GO && signUpFragmentButton.isEnabled) {
+                    signUpFragmentButton.performClick()
+                    true
+                }
+                false
+            }
+
         vm.organization = signupOrganizationEditText.text.toString()
 
         signUpFragmentButton.setOnClickListener {

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -51,7 +51,7 @@
             android:drawableLeft="@drawable/email"
             android:drawableStart="@drawable/email"
             android:inputType="textEmailAddress"
-            android:imeOptions="actionDone"
+            android:imeOptions="actionGo"
             android:drawablePadding="16dp"
             />
 

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -57,7 +57,7 @@
                     android:drawableLeft="@drawable/people"
                     android:drawableStart="@drawable/people"
                     android:inputType="textPersonName"
-                    android:imeOptions="actionDone"
+                    android:imeOptions="actionGo"
                     android:drawablePadding="16dp"
                     android:text="@string/organization_pre_fill"
                     />


### PR DESCRIPTION
Currently pressing enter will hide the keyboard once everything is filled out. The user then needs to press the button to continue signing in. This makes it when the last field has enter pressed on it the user will automatically go to the next screen.