### PR TITLE
Compose camera

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -250,14 +250,16 @@ dependencies {
     api "com.squareup.retrofit2:converter-gson:${retrofit2Version}"
 
     // CameraX core library
-    def camerax_version = "1.0.0-alpha05"
+    def camerax_version = "1.0.0"
     // CameraX view library
-    def camerax_view_version = "1.0.0-alpha02"
+    def camerax_view_version = "1.0.0-alpha22"
     // CameraX extensions library
-    def camerax_ext_version = "1.0.0-alpha02"
+    def camerax_ext_version = "1.0.0-alpha22"
     implementation "androidx.camera:camera-core:$camerax_version"
     // If you want to use Camera2 extensions
     implementation "androidx.camera:camera-camera2:$camerax_version"
+    // CameraX Lifecycle library
+    implementation "androidx.camera:camera-lifecycle:$camerax_version"
     // If you to use the Camera View class
     implementation "androidx.camera:camera-view:$camerax_view_version"
     // If you to use Camera Extensions

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
@@ -11,13 +11,13 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.CameraX
 import androidx.camera.core.ImageCapture
-import androidx.camera.core.ImageCaptureConfig
-import androidx.camera.core.Preview
-import androidx.camera.core.PreviewConfig
+//import androidx.camera.core.ImageCaptureConfig
+//import androidx.camera.core.Preview
+//import androidx.camera.core.PreviewConfig
 import java.io.File
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.models.DeviceOrientation
-import org.greenstand.android.TreeTracker.utilities.AutoFitPreviewBuilder
+//import org.greenstand.android.TreeTracker.utilities.AutoFitPreviewBuilder
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
 import org.greenstand.android.TreeTracker.viewmodels.NewTreeViewModel.Companion.FOCUS_THRESHOLD
 import org.koin.android.ext.android.inject
@@ -25,11 +25,11 @@ import timber.log.Timber
 
 class ImageCaptureActivity : AppCompatActivity() {
 
-    private lateinit var viewFinder: TextureView
-    private lateinit var imageCaptureButton: ImageButton
-    private lateinit var toolbarTitle: TextView
-    private val deviceOrientation by inject<DeviceOrientation>()
-
+//    private lateinit var viewFinder: TextureView
+//    private lateinit var imageCaptureButton: ImageButton
+//    private lateinit var toolbarTitle: TextView
+//    private val deviceOrientation by inject<DeviceOrientation>()
+//
     companion object {
         private const val SELFIE_MODE = "SELFIE_MODE"
 
@@ -42,119 +42,119 @@ class ImageCaptureActivity : AppCompatActivity() {
             }
         }
     }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContentView(R.layout.fragment_camera)
-
-        toolbarTitle = findViewById(R.id.toolbar_title)
-        viewFinder = findViewById(R.id.view_finder)
-        imageCaptureButton = findViewById(R.id.capture_button)
-
-        val captureSelfie = intent.extras?.getBoolean(SELFIE_MODE, false) ?: false
-
-        if (captureSelfie) {
-            toolbarTitle.text = getString(R.string.take_a_selfie)
-        } else {
-            toolbarTitle.text = getString(R.string.add_a_tree)
-        }
-
-        viewFinder.post { startCamera(captureSelfie) }
-    }
-
-    private fun startCamera(captureSelfie: Boolean) {
-        val preview = setupPreview(captureSelfie)
-
-        val lensFacing = if (captureSelfie) CameraX.LensFacing.FRONT else CameraX.LensFacing.BACK
-
-        // Create configuration object for the image capture use case
-        val imageCaptureConfig = ImageCaptureConfig.Builder()
-            .setLensFacing(lensFacing)
-            .setCaptureMode(ImageCapture.CaptureMode.MAX_QUALITY)
-            .setTargetResolution(Size(800, 800))
-            .build()
-
-        val file = ImageUtils.createImageFile(this)
-
-        // Build the image capture use case and attach button click listener
-        val imageCapture = ImageCapture(imageCaptureConfig)
-        imageCaptureButton.setOnClickListener {
-            deviceOrientation.takeSnapshotAndDisable()
-            imageCapture.takePicture(
-                file,
-                object : ImageCapture.OnImageSavedListener {
-                    override fun onError(
-                        imageCaptureError: ImageCapture.ImageCaptureError,
-                        message: String,
-                        cause: Throwable?
-                    ) {
-                        Timber.tag("CameraXApp").e("Photo capture failed: $message")
-                        cause?.printStackTrace()
-                    }
-
-                    override fun onImageSaved(file: File) {
-                        ImageUtils.resizeImage(file.absolutePath, captureSelfie)
-                        Timber.tag("CameraXApp").d("Photo capture succeeded: ${file.absolutePath}")
-                        val focusMetric = testFocusQuality(file)
-
-                        val data = Intent().apply {
-                            putExtra(TAKEN_IMAGE_PATH, file.absolutePath)
-                            // if we can't trust the focus metric (it will be null), because of problems
-                            // generating the metric, we set the quality to "good" to
-                            // avoid false positives. Ultimately, some research would be needed
-                            // into determining the root cause of the false positives, but
-                            // that will be a future effort.
-                            if (focusMetric == null) {
-                                putExtra(FOCUS_METRIC_VALUE, FOCUS_THRESHOLD)
-                            } else {
-                                putExtra(FOCUS_METRIC_VALUE, focusMetric)
-                            }
-                        }
-
-                        setResult(Activity.RESULT_OK, data)
-                        finish()
-                    }
-                }
-            )
-        }
-        CameraX.bindToLifecycle(this, preview, imageCapture)
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-        deviceOrientation.disable()
-    }
-
-    private fun setupPreview(captureSelfie: Boolean): Preview {
-
-        val lensFacing = if (captureSelfie) CameraX.LensFacing.FRONT else CameraX.LensFacing.BACK
-
-        val previewConfig = PreviewConfig.Builder()
-            .setLensFacing(lensFacing)
-            .build()
-
-        return AutoFitPreviewBuilder.build(previewConfig, viewFinder)
-    }
-
-    // Return either the focus metric, or, in the case of an
-    // exception return null.
-    private fun testFocusQuality(imageFile: File): Double? {
-        try {
-            // metric only cares about luminance.
-            // for memory limitations, and performance and metric consistency,
-            // the image is 200 pixels wide.
-            val grayImage = ImageUtils.getGrayPixelFromBitmap(imageFile.absolutePath, 200)
-            if (grayImage.isNullOrEmpty()) {
-                Timber.d("Failed to create Grayscale Image.")
-                return null
-            }
-            return ImageUtils.brennersFocusMetric(grayImage)
-        } catch (e: Exception) {
-            Timber.d("Unable to get focus metric.")
-            Timber.d(e.message)
-        }
-        // on an error, we return null.
-        return null
-    }
+//
+//    override fun onCreate(savedInstanceState: Bundle?) {
+//        super.onCreate(savedInstanceState)
+//
+//        setContentView(R.layout.fragment_camera)
+//
+//        toolbarTitle = findViewById(R.id.toolbar_title)
+//        viewFinder = findViewById(R.id.view_finder)
+//        imageCaptureButton = findViewById(R.id.capture_button)
+//
+//        val captureSelfie = intent.extras?.getBoolean(SELFIE_MODE, false) ?: false
+//
+//        if (captureSelfie) {
+//            toolbarTitle.text = getString(R.string.take_a_selfie)
+//        } else {
+//            toolbarTitle.text = getString(R.string.add_a_tree)
+//        }
+//
+//        viewFinder.post { startCamera(captureSelfie) }
+//    }
+//
+//    private fun startCamera(captureSelfie: Boolean) {
+//        val preview = setupPreview(captureSelfie)
+//
+//        val lensFacing = if (captureSelfie) CameraX.LensFacing.FRONT else CameraX.LensFacing.BACK
+//
+//        // Create configuration object for the image capture use case
+//        val imageCaptureConfig = ImageCaptureConfig.Builder()
+//            .setLensFacing(lensFacing)
+//            .setCaptureMode(ImageCapture.CaptureMode.MAX_QUALITY)
+//            .setTargetResolution(Size(800, 800))
+//            .build()
+//
+//        val file = ImageUtils.createImageFile(this)
+//
+//        // Build the image capture use case and attach button click listener
+//        val imageCapture = ImageCapture(imageCaptureConfig)
+//        imageCaptureButton.setOnClickListener {
+//            deviceOrientation.takeSnapshotAndDisable()
+//            imageCapture.takePicture(
+//                file,
+//                object : ImageCapture.OnImageSavedListener {
+//                    override fun onError(
+//                        imageCaptureError: ImageCapture.ImageCaptureError,
+//                        message: String,
+//                        cause: Throwable?
+//                    ) {
+//                        Timber.tag("CameraXApp").e("Photo capture failed: $message")
+//                        cause?.printStackTrace()
+//                    }
+//
+//                    override fun onImageSaved(file: File) {
+//                        ImageUtils.resizeImage(file.absolutePath, captureSelfie)
+//                        Timber.tag("CameraXApp").d("Photo capture succeeded: ${file.absolutePath}")
+//                        val focusMetric = testFocusQuality(file)
+//
+//                        val data = Intent().apply {
+//                            putExtra(TAKEN_IMAGE_PATH, file.absolutePath)
+//                            // if we can't trust the focus metric (it will be null), because of problems
+//                            // generating the metric, we set the quality to "good" to
+//                            // avoid false positives. Ultimately, some research would be needed
+//                            // into determining the root cause of the false positives, but
+//                            // that will be a future effort.
+//                            if (focusMetric == null) {
+//                                putExtra(FOCUS_METRIC_VALUE, FOCUS_THRESHOLD)
+//                            } else {
+//                                putExtra(FOCUS_METRIC_VALUE, focusMetric)
+//                            }
+//                        }
+//
+//                        setResult(Activity.RESULT_OK, data)
+//                        finish()
+//                    }
+//                }
+//            )
+//        }
+//        CameraX.bindToLifecycle(this, preview, imageCapture)
+//    }
+//
+//    override fun onBackPressed() {
+//        super.onBackPressed()
+//        deviceOrientation.disable()
+//    }
+//
+//    private fun setupPreview(captureSelfie: Boolean): Preview {
+//
+//        val lensFacing = if (captureSelfie) CameraX.LensFacing.FRONT else CameraX.LensFacing.BACK
+//
+//        val previewConfig = PreviewConfig.Builder()
+//            .setLensFacing(lensFacing)
+//            .build()
+//
+//        return AutoFitPreviewBuilder.build(previewConfig, viewFinder)
+//    }
+//
+//    // Return either the focus metric, or, in the case of an
+//    // exception return null.
+//    private fun testFocusQuality(imageFile: File): Double? {
+//        try {
+//            // metric only cares about luminance.
+//            // for memory limitations, and performance and metric consistency,
+//            // the image is 200 pixels wide.
+//            val grayImage = ImageUtils.getGrayPixelFromBitmap(imageFile.absolutePath, 200)
+//            if (grayImage.isNullOrEmpty()) {
+//                Timber.d("Failed to create Grayscale Image.")
+//                return null
+//            }
+//            return ImageUtils.brennersFocusMetric(grayImage)
+//        } catch (e: Exception) {
+//            Timber.d("Unable to get focus metric.")
+//            Timber.d(e.message)
+//        }
+//        // on an error, we return null.
+//        return null
+//    }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/Camera.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/Camera.kt
@@ -72,7 +72,7 @@ fun Camera(
                         )
                         .build()
 
-                    val camera = cameraProvider.bindToLifecycle(
+                    cameraProvider.bindToLifecycle(
                         lifecycleOwner, cameraSelector, preview, imageCapture)
 
                     preview.setSurfaceProvider(previewView.surfaceProvider)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/AutofitPreviewBuilder.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/AutofitPreviewBuilder.kt
@@ -7,218 +7,218 @@ import android.util.Log
 import android.util.Size
 import android.view.*
 import androidx.camera.core.Preview
-import androidx.camera.core.PreviewConfig
+//import androidx.camera.core.PreviewConfig
 import java.lang.ref.WeakReference
 import java.util.*
-
-/**
- * Builder for [Preview] that takes in a [WeakReference] of the view finder and [PreviewConfig],
- * then instantiates a [Preview] which automatically resizes and rotates reacting to config changes.
- */
-class AutoFitPreviewBuilder private constructor(
-    config: PreviewConfig, viewFinderRef: WeakReference<TextureView>) {
-
-    /** Public instance of preview use-case which can be used by consumers of this adapter */
-    val useCase: Preview
-
-    /** Internal variable used to keep track of the use case's output rotation */
-    private var bufferRotation: Int = 0
-
-    /** Internal variable used to keep track of the view's rotation */
-    private var viewFinderRotation: Int? = null
-
-    /** Internal variable used to keep track of the use-case's output dimension */
-    private var bufferDimens: Size = Size(0, 0)
-
-    /** Internal variable used to keep track of the view's dimension */
-    private var viewFinderDimens: Size = Size(0, 0)
-
-    /** Internal variable used to keep track of the view's display */
-    private var viewFinderDisplay: Int = -1
-
-    /** Internal reference of the [DisplayManager] */
-    private lateinit var displayManager: DisplayManager
-
-    /**
-     * We need a display listener for orientation changes that do not trigger a configuration
-     * change, for example if we choose to override config change in manifest or for 180-degree
-     * orientation changes.
-     */
-    private val displayListener = object : DisplayManager.DisplayListener {
-        override fun onDisplayAdded(displayId: Int) = Unit
-        override fun onDisplayRemoved(displayId: Int) = Unit
-        override fun onDisplayChanged(displayId: Int) {
-            val viewFinder = viewFinderRef.get() ?: return
-            if (displayId == viewFinderDisplay) {
-                val display = displayManager.getDisplay(displayId)
-                val rotation = getDisplaySurfaceRotation(display)
-                updateTransform(viewFinder, rotation, bufferDimens, viewFinderDimens)
-            }
-        }
-    }
-
-    init {
-        // Make sure that the view finder reference is valid
-        val viewFinder = viewFinderRef.get() ?:
-        throw IllegalArgumentException("Invalid reference to view finder used")
-
-        // Initialize the display and rotation from texture view information
-        viewFinderDisplay = viewFinder.display.displayId
-        viewFinderRotation = getDisplaySurfaceRotation(viewFinder.display) ?: 0
-
-        // Initialize public use-case with the given config
-        useCase = Preview(config)
-
-        // Every time the view finder is updated, recompute layout
-        useCase.onPreviewOutputUpdateListener = Preview.OnPreviewOutputUpdateListener {
-            val viewFinder =
-                viewFinderRef.get() ?: return@OnPreviewOutputUpdateListener
-            Log.d(TAG, "Preview output changed. " +
-                    "Size: ${it.textureSize}. Rotation: ${it.rotationDegrees}")
-
-            // To update the SurfaceTexture, we have to remove it and re-add it
-            val parent = viewFinder.parent as ViewGroup
-            parent.removeView(viewFinder)
-            parent.addView(viewFinder, 0)
-
-            // Update internal texture
-            viewFinder.surfaceTexture = it.surfaceTexture
-
-            // Apply relevant transformations
-            bufferRotation = it.rotationDegrees
-            val rotation = getDisplaySurfaceRotation(viewFinder.display)
-            updateTransform(viewFinder, rotation, it.textureSize, viewFinderDimens)
-        }
-
-        // Every time the provided texture view changes, recompute layout
-        viewFinder.addOnLayoutChangeListener { view, left, top, right, bottom, _, _, _, _ ->
-            val viewFinder = view as TextureView
-            val newViewFinderDimens = Size(right - left, bottom - top)
-            Log.d(TAG, "View finder layout changed. Size: $newViewFinderDimens")
-            val rotation = getDisplaySurfaceRotation(viewFinder.display)
-            updateTransform(viewFinder, rotation, bufferDimens, newViewFinderDimens)
-        }
-
-        // Every time the orientation of device changes, recompute layout
-        // NOTE: This is unnecessary if we listen to display orientation changes in the camera
-        //  fragment and call [Preview.setTargetRotation()] (like we do in this sample), which will
-        //  trigger [Preview.OnPreviewOutputUpdateListener] with a new
-        //  [PreviewOutput.rotationDegrees]. CameraX Preview use case will not rotate the frames for
-        //  us, it will just tell us about the buffer rotation with respect to sensor orientation.
-        //  In this sample, we ignore the buffer rotation and instead look at the view finder's
-        //  rotation every time [updateTransform] is called, which gets triggered by
-        //  [CameraFragment] display listener -- but the approach taken in this sample is not the
-        //  only valid one.
-        displayManager = viewFinder.context
-            .getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-        displayManager.registerDisplayListener(displayListener, null)
-
-        // Remove the display listeners when the view is detached to avoid holding a reference to
-        //  it outside of the Fragment that owns the view.
-        // NOTE: Even though using a weak reference should take care of this, we still try to avoid
-        //  unnecessary calls to the listener this way.
-        viewFinder.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
-            override fun onViewAttachedToWindow(view: View?) =
-                displayManager.registerDisplayListener(displayListener, null)
-            override fun onViewDetachedFromWindow(view: View?) =
-                displayManager.unregisterDisplayListener(displayListener)
-        })
-    }
-
-    /** Helper function that fits a camera preview into the given [TextureView] */
-    private fun updateTransform(textureView: TextureView?, rotation: Int?, newBufferDimens: Size,
-                                newViewFinderDimens: Size) {
-        // This should not happen anyway, but now the linter knows
-        val textureView = textureView ?: return
-
-        if (rotation == viewFinderRotation &&
-            Objects.equals(newBufferDimens, bufferDimens) &&
-            Objects.equals(newViewFinderDimens, viewFinderDimens)) {
-            // Nothing has changed, no need to transform output again
-            return
-        }
-
-        if (rotation == null) {
-            // Invalid rotation - wait for valid inputs before setting matrix
-            return
-        } else {
-            // Update internal field with new inputs
-            viewFinderRotation = rotation
-        }
-
-        if (newBufferDimens.width == 0 || newBufferDimens.height == 0) {
-            // Invalid buffer dimens - wait for valid inputs before setting matrix
-            return
-        } else {
-            // Update internal field with new inputs
-            bufferDimens = newBufferDimens
-        }
-
-        if (newViewFinderDimens.width == 0 || newViewFinderDimens.height == 0) {
-            // Invalid view finder dimens - wait for valid inputs before setting matrix
-            return
-        } else {
-            // Update internal field with new inputs
-            viewFinderDimens = newViewFinderDimens
-        }
-
-        val matrix = Matrix()
-        Log.d(TAG, "Applying output transformation.\n" +
-                "View finder size: $viewFinderDimens.\n" +
-                "Preview output size: $bufferDimens\n" +
-                "View finder rotation: $viewFinderRotation\n" +
-                "Preview output rotation: $bufferRotation")
-
-        // Compute the center of the view finder
-        val centerX = viewFinderDimens.width / 2f
-        val centerY = viewFinderDimens.height / 2f
-
-        // Correct preview output to account for display rotation
-        matrix.postRotate(-viewFinderRotation!!.toFloat(), centerX, centerY)
-
-        // Buffers are rotated relative to the device's 'natural' orientation: swap width and height
-        val bufferRatio = bufferDimens.height / bufferDimens.width.toFloat()
-
-        val scaledWidth: Int
-        val scaledHeight: Int
-        // Match longest sides together -- i.e. apply center-crop transformation
-        if (viewFinderDimens.width > viewFinderDimens.height) {
-            scaledHeight = viewFinderDimens.width
-            scaledWidth = Math.round(viewFinderDimens.width * bufferRatio)
-        } else {
-            scaledHeight = viewFinderDimens.height
-            scaledWidth = Math.round(viewFinderDimens.height * bufferRatio)
-        }
-
-        // Compute the relative scale value
-        val xScale = scaledWidth / viewFinderDimens.width.toFloat()
-        val yScale = scaledHeight / viewFinderDimens.height.toFloat()
-
-        // Scale input buffers to fill the view finder
-        matrix.preScale(xScale, yScale, centerX, centerY)
-
-        // Finally, apply transformations to our TextureView
-        textureView.setTransform(matrix)
-    }
-
-    companion object {
-        private val TAG = AutoFitPreviewBuilder::class.java.simpleName
-
-        /** Helper function that gets the rotation of a [Display] in degrees */
-        fun getDisplaySurfaceRotation(display: Display?) = when(display?.rotation) {
-            Surface.ROTATION_0 -> 0
-            Surface.ROTATION_90 -> 90
-            Surface.ROTATION_180 -> 180
-            Surface.ROTATION_270 -> 270
-            else -> null
-        }
-
-        /**
-         * Main entrypoint for users of this class: instantiates the adapter and returns an instance
-         * of [Preview] which automatically adjusts in size and rotation to compensate for
-         * config changes.
-         */
-        fun build(config: PreviewConfig, viewFinder: TextureView) =
-            AutoFitPreviewBuilder(config, WeakReference(viewFinder)).useCase
-    }
-}
+//
+///**
+// * Builder for [Preview] that takes in a [WeakReference] of the view finder and [PreviewConfig],
+// * then instantiates a [Preview] which automatically resizes and rotates reacting to config changes.
+// */
+//class AutoFitPreviewBuilder private constructor(
+//    config: PreviewConfig, viewFinderRef: WeakReference<TextureView>) {
+//
+//    /** Public instance of preview use-case which can be used by consumers of this adapter */
+//    val useCase: Preview
+//
+//    /** Internal variable used to keep track of the use case's output rotation */
+//    private var bufferRotation: Int = 0
+//
+//    /** Internal variable used to keep track of the view's rotation */
+//    private var viewFinderRotation: Int? = null
+//
+//    /** Internal variable used to keep track of the use-case's output dimension */
+//    private var bufferDimens: Size = Size(0, 0)
+//
+//    /** Internal variable used to keep track of the view's dimension */
+//    private var viewFinderDimens: Size = Size(0, 0)
+//
+//    /** Internal variable used to keep track of the view's display */
+//    private var viewFinderDisplay: Int = -1
+//
+//    /** Internal reference of the [DisplayManager] */
+//    private lateinit var displayManager: DisplayManager
+//
+//    /**
+//     * We need a display listener for orientation changes that do not trigger a configuration
+//     * change, for example if we choose to override config change in manifest or for 180-degree
+//     * orientation changes.
+//     */
+//    private val displayListener = object : DisplayManager.DisplayListener {
+//        override fun onDisplayAdded(displayId: Int) = Unit
+//        override fun onDisplayRemoved(displayId: Int) = Unit
+//        override fun onDisplayChanged(displayId: Int) {
+//            val viewFinder = viewFinderRef.get() ?: return
+//            if (displayId == viewFinderDisplay) {
+//                val display = displayManager.getDisplay(displayId)
+//                val rotation = getDisplaySurfaceRotation(display)
+//                updateTransform(viewFinder, rotation, bufferDimens, viewFinderDimens)
+//            }
+//        }
+//    }
+//
+//    init {
+//        // Make sure that the view finder reference is valid
+//        val viewFinder = viewFinderRef.get() ?:
+//        throw IllegalArgumentException("Invalid reference to view finder used")
+//
+//        // Initialize the display and rotation from texture view information
+//        viewFinderDisplay = viewFinder.display.displayId
+//        viewFinderRotation = getDisplaySurfaceRotation(viewFinder.display) ?: 0
+//
+//        // Initialize public use-case with the given config
+//        useCase = Preview(config)
+//
+//        // Every time the view finder is updated, recompute layout
+//        useCase.onPreviewOutputUpdateListener = Preview.OnPreviewOutputUpdateListener {
+//            val viewFinder =
+//                viewFinderRef.get() ?: return@OnPreviewOutputUpdateListener
+//            Log.d(TAG, "Preview output changed. " +
+//                    "Size: ${it.textureSize}. Rotation: ${it.rotationDegrees}")
+//
+//            // To update the SurfaceTexture, we have to remove it and re-add it
+//            val parent = viewFinder.parent as ViewGroup
+//            parent.removeView(viewFinder)
+//            parent.addView(viewFinder, 0)
+//
+//            // Update internal texture
+//            viewFinder.surfaceTexture = it.surfaceTexture
+//
+//            // Apply relevant transformations
+//            bufferRotation = it.rotationDegrees
+//            val rotation = getDisplaySurfaceRotation(viewFinder.display)
+//            updateTransform(viewFinder, rotation, it.textureSize, viewFinderDimens)
+//        }
+//
+//        // Every time the provided texture view changes, recompute layout
+//        viewFinder.addOnLayoutChangeListener { view, left, top, right, bottom, _, _, _, _ ->
+//            val viewFinder = view as TextureView
+//            val newViewFinderDimens = Size(right - left, bottom - top)
+//            Log.d(TAG, "View finder layout changed. Size: $newViewFinderDimens")
+//            val rotation = getDisplaySurfaceRotation(viewFinder.display)
+//            updateTransform(viewFinder, rotation, bufferDimens, newViewFinderDimens)
+//        }
+//
+//        // Every time the orientation of device changes, recompute layout
+//        // NOTE: This is unnecessary if we listen to display orientation changes in the camera
+//        //  fragment and call [Preview.setTargetRotation()] (like we do in this sample), which will
+//        //  trigger [Preview.OnPreviewOutputUpdateListener] with a new
+//        //  [PreviewOutput.rotationDegrees]. CameraX Preview use case will not rotate the frames for
+//        //  us, it will just tell us about the buffer rotation with respect to sensor orientation.
+//        //  In this sample, we ignore the buffer rotation and instead look at the view finder's
+//        //  rotation every time [updateTransform] is called, which gets triggered by
+//        //  [CameraFragment] display listener -- but the approach taken in this sample is not the
+//        //  only valid one.
+//        displayManager = viewFinder.context
+//            .getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+//        displayManager.registerDisplayListener(displayListener, null)
+//
+//        // Remove the display listeners when the view is detached to avoid holding a reference to
+//        //  it outside of the Fragment that owns the view.
+//        // NOTE: Even though using a weak reference should take care of this, we still try to avoid
+//        //  unnecessary calls to the listener this way.
+//        viewFinder.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+//            override fun onViewAttachedToWindow(view: View?) =
+//                displayManager.registerDisplayListener(displayListener, null)
+//            override fun onViewDetachedFromWindow(view: View?) =
+//                displayManager.unregisterDisplayListener(displayListener)
+//        })
+//    }
+//
+//    /** Helper function that fits a camera preview into the given [TextureView] */
+//    private fun updateTransform(textureView: TextureView?, rotation: Int?, newBufferDimens: Size,
+//                                newViewFinderDimens: Size) {
+//        // This should not happen anyway, but now the linter knows
+//        val textureView = textureView ?: return
+//
+//        if (rotation == viewFinderRotation &&
+//            Objects.equals(newBufferDimens, bufferDimens) &&
+//            Objects.equals(newViewFinderDimens, viewFinderDimens)) {
+//            // Nothing has changed, no need to transform output again
+//            return
+//        }
+//
+//        if (rotation == null) {
+//            // Invalid rotation - wait for valid inputs before setting matrix
+//            return
+//        } else {
+//            // Update internal field with new inputs
+//            viewFinderRotation = rotation
+//        }
+//
+//        if (newBufferDimens.width == 0 || newBufferDimens.height == 0) {
+//            // Invalid buffer dimens - wait for valid inputs before setting matrix
+//            return
+//        } else {
+//            // Update internal field with new inputs
+//            bufferDimens = newBufferDimens
+//        }
+//
+//        if (newViewFinderDimens.width == 0 || newViewFinderDimens.height == 0) {
+//            // Invalid view finder dimens - wait for valid inputs before setting matrix
+//            return
+//        } else {
+//            // Update internal field with new inputs
+//            viewFinderDimens = newViewFinderDimens
+//        }
+//
+//        val matrix = Matrix()
+//        Log.d(TAG, "Applying output transformation.\n" +
+//                "View finder size: $viewFinderDimens.\n" +
+//                "Preview output size: $bufferDimens\n" +
+//                "View finder rotation: $viewFinderRotation\n" +
+//                "Preview output rotation: $bufferRotation")
+//
+//        // Compute the center of the view finder
+//        val centerX = viewFinderDimens.width / 2f
+//        val centerY = viewFinderDimens.height / 2f
+//
+//        // Correct preview output to account for display rotation
+//        matrix.postRotate(-viewFinderRotation!!.toFloat(), centerX, centerY)
+//
+//        // Buffers are rotated relative to the device's 'natural' orientation: swap width and height
+//        val bufferRatio = bufferDimens.height / bufferDimens.width.toFloat()
+//
+//        val scaledWidth: Int
+//        val scaledHeight: Int
+//        // Match longest sides together -- i.e. apply center-crop transformation
+//        if (viewFinderDimens.width > viewFinderDimens.height) {
+//            scaledHeight = viewFinderDimens.width
+//            scaledWidth = Math.round(viewFinderDimens.width * bufferRatio)
+//        } else {
+//            scaledHeight = viewFinderDimens.height
+//            scaledWidth = Math.round(viewFinderDimens.height * bufferRatio)
+//        }
+//
+//        // Compute the relative scale value
+//        val xScale = scaledWidth / viewFinderDimens.width.toFloat()
+//        val yScale = scaledHeight / viewFinderDimens.height.toFloat()
+//
+//        // Scale input buffers to fill the view finder
+//        matrix.preScale(xScale, yScale, centerX, centerY)
+//
+//        // Finally, apply transformations to our TextureView
+//        textureView.setTransform(matrix)
+//    }
+//
+//    companion object {
+//        private val TAG = AutoFitPreviewBuilder::class.java.simpleName
+//
+//        /** Helper function that gets the rotation of a [Display] in degrees */
+//        fun getDisplaySurfaceRotation(display: Display?) = when(display?.rotation) {
+//            Surface.ROTATION_0 -> 0
+//            Surface.ROTATION_90 -> 90
+//            Surface.ROTATION_180 -> 180
+//            Surface.ROTATION_270 -> 270
+//            else -> null
+//        }
+//
+//        /**
+//         * Main entrypoint for users of this class: instantiates the adapter and returns an instance
+//         * of [Preview] which automatically adjusts in size and rotation to compensate for
+//         * config changes.
+//         */
+//        fun build(config: PreviewConfig, viewFinder: TextureView) =
+//            AutoFitPreviewBuilder(config, WeakReference(viewFinder)).useCase
+//    }
+//}


### PR DESCRIPTION
Setup basic camera capture for compose.

This involved updating the camera library which broke the activity implementation. This is why it's all commented out. Let's leave the code commented out for now in case we need to reference it.

Some tweaks may have to happen later, but this gives us a working camera to use in our navigation.