### PR TITLE
#614 - Update WalletSelectScreen to include selfie image in the top left corner

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -304,6 +304,6 @@ afterEvaluate {
     // ktlint git precommit hook is insalled to .git folder in project root when running app in
     // Intellij by the developer or when triggering gradle build. This ensures ktlint format is
     // executed before code is committed.
-//    tasks["preBuild"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
-//    tasks["clean"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
+    tasks["preBuild"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
+    tasks["clean"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -304,6 +304,6 @@ afterEvaluate {
     // ktlint git precommit hook is insalled to .git folder in project root when running app in
     // Intellij by the developer or when triggering gradle build. This ensures ktlint format is
     // executed before code is committed.
-    tasks["preBuild"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
-    tasks["clean"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
+//    tasks["preBuild"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
+//    tasks["clean"].dependsOn parent.tasks.findByName("addKtlintFormatGitPreCommitHook")
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/ImageReviewScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/ImageReviewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import org.greenstand.android.TreeTracker.activities.CaptureImageContract
 import org.greenstand.android.TreeTracker.activities.LocalNavHostController
@@ -49,9 +50,10 @@ fun ImageReviewScreen(photoPath: String) {
         }
     ) {
         LocalImage(
+            modifier = Modifier.fillMaxSize(),
             imagePath = photoPath,
             contentDescription = null,
-            modifier = Modifier.fillMaxSize()
+            contentScale = ContentScale.Fit
         )
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
@@ -113,14 +113,18 @@ fun UserButton(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // User profile picture.
-            Box(  // TODO: Fetch user profile picture.
+            Box(
                 modifier = Modifier
                     .padding(1.dp)
                     .fillMaxWidth()
                     .aspectRatio(1.0f)
-                    .clip(RoundedCornerShape(5.dp))
+                    .clip(RoundedCornerShape(10.dp))
                     .background(AppColors.LightGray)
-            )  // Box placeholder for user profile picture.
+            ) {
+                LocalImage(
+                    imagePath = user.photoPath,
+                    modifier = Modifier.fillMaxSize().aspectRatio(0.6f))
+            }  // Box placeholder for user profile picture.
 
             // User text data: Name, phone number, and token count.
             Column(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -113,18 +114,15 @@ fun UserButton(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             // User profile picture.
-            Box(
+            LocalImage(
+                imagePath = user.photoPath,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
-                    .padding(1.dp)
                     .fillMaxWidth()
+                    .wrapContentHeight()
                     .aspectRatio(1.0f)
-                    .clip(RoundedCornerShape(10.dp))
-                    .background(AppColors.LightGray)
-            ) {
-                LocalImage(
-                    imagePath = user.photoPath,
-                    modifier = Modifier.fillMaxSize().aspectRatio(0.6f))
-            }  // Box placeholder for user profile picture.
+                    .clip(RoundedCornerShape(percent = 10))
+            )
 
             // User text data: Name, phone number, and token count.
             Column(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
@@ -2,11 +2,6 @@ package org.greenstand.android.TreeTracker.view
 
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
@@ -6,12 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun LocalImage(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
@@ -2,13 +2,21 @@ package org.greenstand.android.TreeTracker.view
 
 import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun LocalImage(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/Images.kt
@@ -9,19 +9,22 @@ import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 
 @Composable
 fun LocalImage(
     modifier: Modifier = Modifier,
     imagePath: String,
     contentDescription: String? = null,
+    contentScale: ContentScale,
 ) {
     val bitmap by loadLocalImage(imagePath = imagePath)
     bitmap?.let {
         Image(
             bitmap = it,
             contentDescription = contentDescription,
-            modifier = modifier
+            modifier = modifier,
+            contentScale = contentScale
         )
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -1,11 +1,10 @@
 package org.greenstand.android.TreeTracker.walletselect
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -14,15 +13,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.greenstand.android.TreeTracker.activities.LocalNavHostController
 import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
+import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.models.user.User
-import org.greenstand.android.TreeTracker.view.ActionBar
-import org.greenstand.android.TreeTracker.view.ArrowButton
-import org.greenstand.android.TreeTracker.view.DepthButton
-import org.greenstand.android.TreeTracker.view.LanguageButton
+import org.greenstand.android.TreeTracker.view.*
 
 @Composable
 fun WalletSelectScreen(
@@ -41,12 +39,22 @@ fun WalletSelectScreen(
     Scaffold(
         topBar = {
             ActionBar(
-                rightAction = { LanguageButton() },
-                centerAction = {
-                    Text("Treetracker", modifier = Modifier.align(Alignment.Center))
-                },
                 leftAction = {
-                    // selfie image
+                    Box(
+                        modifier = Modifier
+                            .width(100.dp)
+                            .height(100.dp)
+                            .padding(15.dp, 10.dp, 10.dp, 10.dp)
+                            .aspectRatio(1.0f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(AppColors.LightGray)
+                    ) {
+                        state.selectedUser?.photoPath?.let {
+                            LocalImage(
+                                imagePath = it,
+                                modifier = Modifier.fillMaxSize().aspectRatio(0.6f))
+                        }
+                    }
                 }
             )
         },

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -14,11 +14,11 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.greenstand.android.TreeTracker.activities.LocalNavHostController
 import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
-import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.models.user.User
 import org.greenstand.android.TreeTracker.view.*
 
@@ -40,20 +40,17 @@ fun WalletSelectScreen(
         topBar = {
             ActionBar(
                 leftAction = {
-                    Box(
-                        modifier = Modifier
-                            .width(100.dp)
-                            .height(100.dp)
-                            .padding(15.dp, 10.dp, 10.dp, 10.dp)
-                            .aspectRatio(1.0f)
-                            .clip(RoundedCornerShape(10.dp))
-                            .background(AppColors.LightGray)
-                    ) {
-                        state.selectedUser?.photoPath?.let {
-                            LocalImage(
-                                imagePath = it,
-                                modifier = Modifier.fillMaxSize().aspectRatio(0.6f))
-                        }
+                    state.selectedUser?.photoPath?.let {
+                        LocalImage(
+                            modifier = Modifier
+                                .width(100.dp)
+                                .height(100.dp)
+                                .padding(15.dp, 10.dp, 10.dp, 10.dp)
+                                .aspectRatio(1.0f)
+                                .clip(RoundedCornerShape(percent = 10)),
+                            imagePath = it,
+                            contentScale = ContentScale.Crop
+                        )
                     }
                 }
             )


### PR DESCRIPTION
Implemented the selfie on the top left corner of the Wallet selection screen. Also added the user's image on that selfie and also on the user selection screen.

A demo of how that's behaving:

https://user-images.githubusercontent.com/7141687/120409660-c5868380-c327-11eb-9bfe-8a36b458eeb2.mov