### PR TITLE
Add tree capture screen

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
@@ -9,11 +9,10 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import org.greenstand.android.TreeTracker.camera.CameraScreen
-import org.greenstand.android.TreeTracker.camera.ImageReviewScreen
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.addNavRoute
 import org.greenstand.android.TreeTracker.view.TreeTrackerTheme
 
 
@@ -72,21 +71,11 @@ class ImageCaptureActivity : AppCompatActivity() {
                 LocalNavHostController provides navController
             ) {
                 TreeTrackerTheme {
-                    NavHost(navController, startDestination = NavRoute.Camera.route) {
-                        composable(
-                            route = NavRoute.Camera.route,
-                        ) {
-                            CameraScreen(isSelfieMode = captureSelfie) {
-                                navController.navigate(NavRoute.ImageReview.create(it.path))
-                            }
-                        }
-
-                        composable(
-                            route = NavRoute.ImageReview.route,
-                            arguments = NavRoute.ImageReview.arguments,
-                        ) { backStackEntry ->
-                            ImageReviewScreen(photoPath = NavRoute.ImageReview.photoPath(backStackEntry))
-                        }
+                    NavHost(navController, startDestination = NavRoute.Selfie.route) {
+                        listOf(
+                            NavRoute.Selfie,
+                            NavRoute.ImageReview,
+                        ).forEach { addNavRoute(it) }
                     }
                 }
             }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/TreeTrackerActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/TreeTrackerActivity.kt
@@ -3,27 +3,13 @@ package org.greenstand.android.TreeTracker.activities
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.*
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
-import org.greenstand.android.TreeTracker.camera.CameraScreen
-import org.greenstand.android.TreeTracker.dashboard.DashboardScreen
-import org.greenstand.android.TreeTracker.languagepicker.LanguageSelectScreen
-import org.greenstand.android.TreeTracker.models.*
-import org.greenstand.android.TreeTracker.orgpicker.OrgPickerScreen
-import org.greenstand.android.TreeTracker.signup.NameEntryView
-import org.greenstand.android.TreeTracker.signup.SignupFlow
-import org.greenstand.android.TreeTracker.splash.SplashScreen
-import org.greenstand.android.TreeTracker.userselect.UserSelectScreen
-import org.greenstand.android.TreeTracker.view.TreeTrackerTheme
-import org.greenstand.android.TreeTracker.walletselect.WalletSelectScreen
+import androidx.compose.runtime.ExperimentalComposeApi
+import org.greenstand.android.TreeTracker.models.FeatureFlags
+import org.greenstand.android.TreeTracker.models.Language
+import org.greenstand.android.TreeTracker.models.LanguageSwitcher
+import org.greenstand.android.TreeTracker.models.TreeTrackerViewModelFactory
+import org.greenstand.android.TreeTracker.root.Root
 import org.koin.android.ext.android.inject
-
-val LocalViewModelFactory = compositionLocalOf<TreeTrackerViewModelFactory> { error { "No active ViewModel factory found!" } }
-val LocalNavHostController = compositionLocalOf<NavHostController> { error { "No NavHostController found!" } }
 
 class TreeTrackerActivity : ComponentActivity() {
 
@@ -41,75 +27,7 @@ class TreeTrackerActivity : ComponentActivity() {
         }
 
         setContent {
-            val navController = rememberNavController()
-
-            CompositionLocalProvider(
-                LocalViewModelFactory provides viewModelFactory,
-                LocalNavHostController provides navController
-            ) {
-                Host()
-            }
-        }
-    }
-}
-
-@ExperimentalComposeApi
-@Composable
-private fun Host() {
-
-    val navController = LocalNavHostController.current
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-
-    TreeTrackerTheme {
-        NavHost(navController, startDestination = NavRoute.Splash.route) {
-            composable(NavRoute.Splash.route) {
-                SplashScreen()
-            }
-
-            composable(
-                route = NavRoute.Language.route,
-                arguments = NavRoute.Language.arguments
-            ) { backStackEntry ->
-                LanguageSelectScreen(
-                    isFromTopBar = NavRoute.Language.isFromTopBar(backStackEntry)
-                )
-            }
-
-            composable(NavRoute.SignupFlow.route) {
-                SignupFlow()
-            }
-
-            composable(NavRoute.NameEntryView.route) {
-                NameEntryView()
-            }
-
-            composable(NavRoute.Dashboard.route) {
-                DashboardScreen()
-            }
-
-            composable(NavRoute.Org.route) {
-                OrgPickerScreen()
-            }
-
-            composable(NavRoute.UserSelect.route) {
-                UserSelectScreen()
-            }
-
-            composable(
-                route = NavRoute.WalletSelect.route,
-                arguments = NavRoute.WalletSelect.arguments
-            ) {
-                WalletSelectScreen(planterInfoId = NavRoute.WalletSelect.getPlanterInfoId(it))
-            }
-
-            composable(
-                route = NavRoute.Camera.route,
-                arguments = NavRoute.Camera.arguments
-            ) {
-                CameraScreen(
-                    isSelfieMode = NavRoute.Camera.isSelfieMode(it)
-                )
-            }
+            Root(viewModelFactory)
         }
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/ImageReviewScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/ImageReviewScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import org.greenstand.android.TreeTracker.activities.CaptureImageContract
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
 import org.greenstand.android.TreeTracker.view.LocalImage
 
 @Composable
@@ -30,9 +30,9 @@ fun ImageReviewScreen(photoPath: String) {
                 horizontalArrangement = Arrangement.Center
             ) {
                 Button(onClick = {
-                    navController.navigate(NavRoute.Camera.create(isSelfieMode = true)) {
+                    navController.navigate(NavRoute.Selfie.route) {
                         launchSingleTop = true
-                        popUpTo(NavRoute.Camera.route) { inclusive = true }
+                        popUpTo(NavRoute.Selfie.route) { inclusive = true }
                     }
                 }) {
                     Text("Retake")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/SelfieScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/SelfieScreen.kt
@@ -9,20 +9,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import java.io.File
+import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
 
 @Composable
-fun CameraScreen(
-    isSelfieMode: Boolean,
-    onImageResult: (File) -> Unit = {}
-) {
-
+fun SelfieScreen() {
+    val navController = LocalNavHostController.current
     val cameraControl = remember { CameraControl() }
     Camera(
-        isSelfieMode = isSelfieMode,
+        isSelfieMode = true,
         cameraControl = cameraControl,
         onImageCaptured = {
-            onImageResult(it)
+            navController.navigate(NavRoute.ImageReview.create(it.path))
         }
     )
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -1,0 +1,78 @@
+package org.greenstand.android.TreeTracker.capture
+
+import android.util.Log
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.greenstand.android.TreeTracker.camera.Camera
+import org.greenstand.android.TreeTracker.camera.CameraControl
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.view.ActionBar
+import org.greenstand.android.TreeTracker.view.ArrowButton
+import org.greenstand.android.TreeTracker.view.LocalImage
+
+@Composable
+fun TreeCaptureScreen(
+    profilePicUrl: String,
+    viewModel: TreeCaptureViewModel = viewModel(factory = TreeCaptureViewModelFactory(profilePicUrl))
+) {
+    val state by viewModel.state.observeAsState(TreeCaptureState(profilePicUrl))
+    val navController = LocalNavHostController.current
+    val cameraControl = remember { CameraControl() }
+
+    Log.d("JONATHAN", "Capture Screen")
+    Scaffold(
+        topBar = {
+            ActionBar(
+                leftAction = {
+                    LocalImage(
+                        modifier = Modifier
+                            .width(100.dp)
+                            .height(100.dp)
+                            .padding(15.dp, 10.dp, 10.dp, 10.dp)
+                            .aspectRatio(1.0f)
+                            .clip(RoundedCornerShape(percent = 10)),
+                        imagePath = state.profilePicUrl,
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            )
+        },
+        bottomBar = {
+            ActionBar(
+                leftAction = {
+                    ArrowButton(isLeft = true) {
+                        navController.popBackStack()
+                    }
+                },
+                rightAction = {
+                    ArrowButton(
+                        isLeft = false,
+                    ) {
+
+                    }
+                }
+            )
+        }
+    ) {
+        Camera(
+            isSelfieMode = false,
+            cameraControl = cameraControl,
+            onImageCaptured = {
+
+            }
+        )
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -1,6 +1,5 @@
 package org.greenstand.android.TreeTracker.capture
 
-import android.util.Log
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -26,30 +25,13 @@ import org.greenstand.android.TreeTracker.view.LocalImage
 @Composable
 fun TreeCaptureScreen(
     profilePicUrl: String,
-    viewModel: TreeCaptureViewModel = viewModel(factory = TreeCaptureViewModelFactory(profilePicUrl))
 ) {
+    val viewModel: TreeCaptureViewModel = viewModel(factory = TreeCaptureViewModelFactory(profilePicUrl))
     val state by viewModel.state.observeAsState(TreeCaptureState(profilePicUrl))
     val navController = LocalNavHostController.current
     val cameraControl = remember { CameraControl() }
 
-    Log.d("JONATHAN", "Capture Screen")
     Scaffold(
-        topBar = {
-            ActionBar(
-                leftAction = {
-                    LocalImage(
-                        modifier = Modifier
-                            .width(100.dp)
-                            .height(100.dp)
-                            .padding(15.dp, 10.dp, 10.dp, 10.dp)
-                            .aspectRatio(1.0f)
-                            .clip(RoundedCornerShape(percent = 10)),
-                        imagePath = state.profilePicUrl,
-                        contentScale = ContentScale.Crop
-                    )
-                }
-            )
-        },
         bottomBar = {
             ActionBar(
                 leftAction = {
@@ -72,6 +54,20 @@ fun TreeCaptureScreen(
             cameraControl = cameraControl,
             onImageCaptured = {
 
+            }
+        )
+        ActionBar(
+            leftAction = {
+                LocalImage(
+                    modifier = Modifier
+                        .width(100.dp)
+                        .height(100.dp)
+                        .padding(15.dp, 10.dp, 10.dp, 10.dp)
+                        .aspectRatio(1.0f)
+                        .clip(RoundedCornerShape(percent = 10)),
+                    imagePath = state.profilePicUrl,
+                    contentScale = ContentScale.Crop
+                )
             }
         )
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
@@ -1,6 +1,5 @@
 package org.greenstand.android.TreeTracker.capture
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -20,7 +19,6 @@ class TreeCaptureViewModel(profilePicUrl: String) : ViewModel() {
 class TreeCaptureViewModelFactory(private val profilePicUrl: String) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        Log.d("JONATHAN", "FACTORY")
         return TreeCaptureViewModel(profilePicUrl) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
@@ -1,0 +1,26 @@
+package org.greenstand.android.TreeTracker.capture
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+data class TreeCaptureState(
+    val profilePicUrl: String,
+)
+
+class TreeCaptureViewModel(profilePicUrl: String) : ViewModel() {
+
+    private val _state = MutableLiveData(TreeCaptureState(profilePicUrl))
+    val state: LiveData<TreeCaptureState> = _state
+
+}
+
+class TreeCaptureViewModelFactory(private val profilePicUrl: String) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        Log.d("JONATHAN", "FACTORY")
+        return TreeCaptureViewModel(profilePicUrl) as T
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardScreen.kt
@@ -1,7 +1,16 @@
 package org.greenstand.android.TreeTracker.dashboard
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ButtonColors
+import androidx.compose.material.Scaffold
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.Text
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.rememberCoroutineScope
@@ -15,12 +24,18 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.NavRoute
-import org.greenstand.android.TreeTracker.view.*
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
+import org.greenstand.android.TreeTracker.view.ActionBar
+import org.greenstand.android.TreeTracker.view.AppButtonColors
+import org.greenstand.android.TreeTracker.view.DepthButton
+import org.greenstand.android.TreeTracker.view.LanguageButton
+import org.greenstand.android.TreeTracker.view.TextButton
+import org.greenstand.android.TreeTracker.view.TextStyles
+import org.greenstand.android.TreeTracker.view.TopBarTitle
 
-@ExperimentalComposeApi
+@OptIn(ExperimentalComposeApi::class)
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel = viewModel(factory = LocalViewModelFactory.current),

--- a/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguageSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguageSelectScreen.kt
@@ -19,10 +19,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.Language
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.ArrowButton
 import org.greenstand.android.TreeTracker.view.DepthButton

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/NavRoute.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/NavRoute.kt
@@ -1,57 +1,76 @@
 package org.greenstand.android.TreeTracker.models
 
+import androidx.compose.runtime.Composable
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavType
 import androidx.navigation.compose.NamedNavArgument
 import androidx.navigation.compose.navArgument
+import org.greenstand.android.TreeTracker.camera.ImageReviewScreen
+import org.greenstand.android.TreeTracker.camera.SelfieScreen
+import org.greenstand.android.TreeTracker.capture.TreeCaptureScreen
+import org.greenstand.android.TreeTracker.dashboard.DashboardScreen
+import org.greenstand.android.TreeTracker.languagepicker.LanguageSelectScreen
+import org.greenstand.android.TreeTracker.orgpicker.OrgPickerScreen
+import org.greenstand.android.TreeTracker.signup.NameEntryView
+import org.greenstand.android.TreeTracker.signup.SignupFlow
+import org.greenstand.android.TreeTracker.splash.SplashScreen
+import org.greenstand.android.TreeTracker.userselect.UserSelectScreen
+import org.greenstand.android.TreeTracker.walletselect.WalletSelectScreen
 
 sealed class NavRoute {
 
+    abstract val content: @Composable (NavBackStackEntry) -> Unit
     abstract val route: String
     open val arguments: List<NamedNavArgument> = emptyList()
     open val deepLinks: List<NavDeepLink> = emptyList()
 
     object Splash : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            SplashScreen()
+        }
         override val route: String = "splash"
     }
 
-    object Phone : NavRoute() {
-        override val route: String = "phone"
-    }
-
     object SignupFlow : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            SignupFlow()
+        }
         override val route: String = "signup-flow"
     }
 
     object NameEntryView : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            NameEntryView()
+        }
         override val route: String = "signup-flow/nameEntryView"
     }
 
-    object Name : NavRoute() {
-        override val route: String = "name/{identifier}"
-        override val arguments = listOf(navArgument("identifier") { type = NavType.StringType })
-
-        fun getIdentifier(backStackEntry: NavBackStackEntry): Boolean {
-            return backStackEntry.arguments?.getBoolean("identifier") ?: false
-        }
-
-        fun create(identifier: Boolean) = "camera/$identifier"
-    }
-
     object Org : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            OrgPickerScreen()
+        }
         override val route: String = "org"
     }
 
     object Dashboard : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            DashboardScreen()
+        }
         override val route: String = "dashboard"
     }
 
     object UserSelect : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            UserSelectScreen()
+        }
         override val route: String = "user-select"
     }
 
     object WalletSelect : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            WalletSelectScreen(getPlanterInfoId(it))
+        }
         override val route: String = "wallet-select/{planterInfoId}"
         override val arguments = listOf(navArgument("planterInfoId") { type = NavType.LongType })
 
@@ -62,18 +81,17 @@ sealed class NavRoute {
         fun create(planterInfoId: Long) = "wallet-select/$planterInfoId"
     }
 
-    object Camera : NavRoute() {
-        override val route: String = "camera/{isSelfieMode}"
-        override val arguments = listOf(navArgument("isSelfieMode") { type = NavType.BoolType })
-
-        fun isSelfieMode(backStackEntry: NavBackStackEntry): Boolean {
-            return backStackEntry.arguments?.getBoolean("isSelfieMode") ?: false
+    object Selfie : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            SelfieScreen()
         }
-
-        fun create(isSelfieMode: Boolean) = "camera/$isSelfieMode"
+        override val route: String = "selfie"
     }
 
     object ImageReview : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            ImageReviewScreen(photoPath(it))
+        }
         override val route: String = "camera-review/{photoPath}"
         override val arguments = listOf(navArgument("photoPath") { type = NavType.StringType })
 
@@ -87,6 +105,9 @@ sealed class NavRoute {
     }
 
     object Language : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            LanguageSelectScreen(isFromTopBar(it))
+        }
         override val route: String = "language/{isFromTopBar}"
         override val arguments = listOf(navArgument("isFromTopBar") { type = NavType.BoolType })
 
@@ -95,5 +116,19 @@ sealed class NavRoute {
         }
 
         fun create(isFromTopBar: Boolean = true) = "language/$isFromTopBar"
+    }
+
+    object TreeCapture : NavRoute() {
+        override val content: @Composable (NavBackStackEntry) -> Unit =  {
+            TreeCaptureScreen(getProfilePicUrl(it))
+        }
+        override val route: String = "tree-capture/{profilePicUrl}"
+        override val arguments = listOf(navArgument("profilePicUrl") { type = NavType.StringType })
+
+        fun getProfilePicUrl(backStackEntry: NavBackStackEntry): String {
+            return backStackEntry.arguments?.getString("profilePicUrl", "") ?: ""
+        }
+
+        fun create(profilePicUrl: String) = "tree-capture/$profilePicUrl"
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/NavRoute.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/NavRoute.kt
@@ -74,7 +74,7 @@ sealed class NavRoute {
         override val route: String = "wallet-select/{planterInfoId}"
         override val arguments = listOf(navArgument("planterInfoId") { type = NavType.LongType })
 
-        fun getPlanterInfoId(backStackEntry: NavBackStackEntry): Long {
+        private fun getPlanterInfoId(backStackEntry: NavBackStackEntry): Long {
             return backStackEntry.arguments?.getLong("planterInfoId") ?: -1
         }
 
@@ -96,11 +96,11 @@ sealed class NavRoute {
         override val arguments = listOf(navArgument("photoPath") { type = NavType.StringType })
 
         fun photoPath(backStackEntry: NavBackStackEntry): String {
-            return backStackEntry.arguments?.getString("photoPath")?.replace('*', '/') ?: ""
+            return backStackEntry.arguments?.getString("photoPath").fromSafeNavUrl()
         }
 
         fun create(photoPath: String): String {
-            return "camera-review/${photoPath.replace('/', '*')}"
+            return "camera-review/${photoPath.toSafeNavUrl()}"
         }
     }
 
@@ -111,7 +111,7 @@ sealed class NavRoute {
         override val route: String = "language/{isFromTopBar}"
         override val arguments = listOf(navArgument("isFromTopBar") { type = NavType.BoolType })
 
-        fun isFromTopBar(backStackEntry: NavBackStackEntry): Boolean {
+        private fun isFromTopBar(backStackEntry: NavBackStackEntry): Boolean {
             return backStackEntry.arguments?.getBoolean("isFromTopBar") ?: false
         }
 
@@ -122,13 +122,19 @@ sealed class NavRoute {
         override val content: @Composable (NavBackStackEntry) -> Unit =  {
             TreeCaptureScreen(getProfilePicUrl(it))
         }
-        override val route: String = "tree-capture/{profilePicUrl}"
+        override val route: String = "capture/{profilePicUrl}"
         override val arguments = listOf(navArgument("profilePicUrl") { type = NavType.StringType })
 
-        fun getProfilePicUrl(backStackEntry: NavBackStackEntry): String {
-            return backStackEntry.arguments?.getString("profilePicUrl", "") ?: ""
+        private fun getProfilePicUrl(backStackEntry: NavBackStackEntry): String {
+            return backStackEntry.arguments?.getString("profilePicUrl", "").fromSafeNavUrl()
         }
 
-        fun create(profilePicUrl: String) = "tree-capture/$profilePicUrl"
+        fun create(profilePicUrl: String) = "capture/${profilePicUrl.toSafeNavUrl()}"
     }
 }
+
+// Navigation uses '/' to denote params or nesting. Having a param that contains '/'
+// will break the navigation. These replace '/' with '*' while navigating
+private fun String?.toSafeNavUrl(): String = this?.replace('/', '*') ?: ""
+private fun String?.fromSafeNavUrl(): String = this?.replace('*', '/') ?: ""
+

--- a/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/OrgPickerScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/OrgPickerScreen.kt
@@ -2,7 +2,14 @@ package org.greenstand.android.TreeTracker.orgpicker
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Scaffold
@@ -17,10 +24,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.Org
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 
 @Composable
 fun OrgPickerScreen(viewModel: OrgPickerViewModel = viewModel(factory = LocalViewModelFactory.current)) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/root/Host.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/root/Host.kt
@@ -1,0 +1,49 @@
+package org.greenstand.android.TreeTracker.root
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.get
+import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.view.TreeTrackerTheme
+
+@ExperimentalComposeApi
+@Composable
+fun Host() {
+
+    val navController = LocalNavHostController.current
+
+    TreeTrackerTheme {
+        NavHost(navController, startDestination = NavRoute.Splash.route) {
+            listOf(
+                NavRoute.Splash,
+                NavRoute.Language,
+                NavRoute.SignupFlow,
+                NavRoute.NameEntryView,
+                NavRoute.Dashboard,
+                NavRoute.Org,
+                NavRoute.UserSelect,
+                NavRoute.WalletSelect,
+                NavRoute.Selfie,
+                NavRoute.TreeCapture,
+            ).forEach { addNavRoute(it) }
+        }
+    }
+}
+
+
+fun NavGraphBuilder.addNavRoute(navRoute: NavRoute) {
+    addDestination(
+        ComposeNavigator.Destination(provider[ComposeNavigator::class], navRoute.content).apply {
+            this.route = navRoute.route
+            navRoute.arguments.forEach { (argumentName, argument) ->
+                addArgument(argumentName, argument)
+            }
+            navRoute.deepLinks.forEach { deepLink ->
+                addDeepLink(deepLink)
+            }
+        }
+    )
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
@@ -1,0 +1,25 @@
+package org.greenstand.android.TreeTracker.root
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.runtime.compositionLocalOf
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import org.greenstand.android.TreeTracker.models.TreeTrackerViewModelFactory
+
+val LocalViewModelFactory = compositionLocalOf<TreeTrackerViewModelFactory> { error { "No active ViewModel factory found!" } }
+val LocalNavHostController = compositionLocalOf<NavHostController> { error { "No NavHostController found!" } }
+
+@ExperimentalComposeApi
+@Composable
+fun Root(viewModelFactory: TreeTrackerViewModelFactory) {
+    val navController = rememberNavController()
+
+    CompositionLocalProvider(
+        LocalViewModelFactory provides viewModelFactory,
+        LocalNavHostController provides navController
+    ) {
+        Host()
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
@@ -24,9 +24,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.activities.CaptureImageContract
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.ArrowButton
 import org.greenstand.android.TreeTracker.view.BorderedTextField

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/SignupScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/SignupScreen.kt
@@ -1,6 +1,13 @@
 package org.greenstand.android.TreeTracker.signup
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Scaffold
@@ -19,14 +26,20 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.greenstand.android.TreeTracker.R
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.NavRoute
-import org.greenstand.android.TreeTracker.view.*
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
+import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.AppColors.GrayShadow
 import org.greenstand.android.TreeTracker.view.AppColors.Green
 import org.greenstand.android.TreeTracker.view.AppColors.GreenShadow
 import org.greenstand.android.TreeTracker.view.AppColors.MediumGray
+import org.greenstand.android.TreeTracker.view.ArrowButton
+import org.greenstand.android.TreeTracker.view.BorderedTextField
+import org.greenstand.android.TreeTracker.view.DepthButton
+import org.greenstand.android.TreeTracker.view.DepthButtonColors
+import org.greenstand.android.TreeTracker.view.LanguageButton
+import org.greenstand.android.TreeTracker.view.TopBarTitle
 
 @Composable
 fun SignupFlow(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/splash/SplashScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/splash/SplashScreen.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.BuildConfig
 import org.greenstand.android.TreeTracker.R
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import timber.log.Timber
 
 @Composable

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
@@ -2,7 +2,16 @@ package org.greenstand.android.TreeTracker.userselect
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.GridCells
 import androidx.compose.foundation.lazy.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
@@ -22,11 +31,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.greenstand.android.TreeTracker.R
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.models.user.User
-import org.greenstand.android.TreeTracker.view.*
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
+import org.greenstand.android.TreeTracker.view.ActionBar
+import org.greenstand.android.TreeTracker.view.AppColors
+import org.greenstand.android.TreeTracker.view.DepthButton
+import org.greenstand.android.TreeTracker.view.DepthButtonColors
+import org.greenstand.android.TreeTracker.view.LocalImage
+import org.greenstand.android.TreeTracker.view.TextButton
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/TextButton.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/TextButton.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import org.greenstand.android.TreeTracker.R
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
 
 @Composable
 fun TextButton(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -1,7 +1,13 @@
 package org.greenstand.android.TreeTracker.walletselect
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,10 +23,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import org.greenstand.android.TreeTracker.activities.LocalNavHostController
-import org.greenstand.android.TreeTracker.activities.LocalViewModelFactory
+import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.models.user.User
-import org.greenstand.android.TreeTracker.view.*
+import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
+import org.greenstand.android.TreeTracker.view.ActionBar
+import org.greenstand.android.TreeTracker.view.ArrowButton
+import org.greenstand.android.TreeTracker.view.DepthButton
+import org.greenstand.android.TreeTracker.view.LocalImage
 
 @Composable
 fun WalletSelectScreen(
@@ -62,6 +72,11 @@ fun WalletSelectScreen(
                         isLeft = false,
                         isEnabled = state.selectedUser != null
                     ) {
+                        Log.d("JONATHAN", "Click arrow")
+                        state.currentUser?.photoPath?.let {
+                            Log.d("JONATHAN", "navigating")
+                            navController.navigate(NavRoute.TreeCapture.create(it))
+                        }
                     }
                 },
                 leftAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -1,6 +1,5 @@
 package org.greenstand.android.TreeTracker.walletselect
 
-import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -72,9 +71,7 @@ fun WalletSelectScreen(
                         isLeft = false,
                         isEnabled = state.selectedUser != null
                     ) {
-                        Log.d("JONATHAN", "Click arrow")
                         state.currentUser?.photoPath?.let {
-                            Log.d("JONATHAN", "navigating")
                             navController.navigate(NavRoute.TreeCapture.create(it))
                         }
                     }


### PR DESCRIPTION
- Added basic tree capture screen (doesn't actually capture anything yet)
- Refactored navigation routes to require less coding when a new route is added. This should keep everything related to a route in the single route class
- Moved compose logic out of TreeTracker activity


![capture_screen](https://user-images.githubusercontent.com/6439445/120907204-b0fb0180-c62d-11eb-9834-464b8f5cd8fa.png)
