### PR TITLE
fix: profile image bug for wallets

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -47,11 +47,12 @@ fun WalletSelectScreen(
 
     val navController = LocalNavHostController.current
 
+
     Scaffold(
         topBar = {
             ActionBar(
                 leftAction = {
-                    state.selectedUser?.photoPath?.let {
+                    state.currentUser?.photoPath?.let {
                         LocalImage(
                             modifier = Modifier
                                 .width(100.dp)


### PR DESCRIPTION
`state.selectedUser` would create a bug where the profile image would change with every click on a different wallet . `state.currentUser` means the profile image is constant with the current signed in user. Which is the desired effect.