### PR TITLE
prevent keyboard from closing in signup flow

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -39,6 +41,7 @@ import org.greenstand.android.TreeTracker.view.TopBarTitle
 @Composable
 fun CredentialEntryView(viewModel: SignupViewModel, state: SignUpState) {
     val navController = LocalNavHostController.current
+    val focusRequester = remember { FocusRequester() }
 
     Scaffold(
         topBar = {
@@ -108,7 +111,10 @@ fun CredentialEntryView(viewModel: SignupViewModel, state: SignUpState) {
                         onGo = {
                             viewModel.goToNameEntry()
                         }
-                    )
+                    ),
+                    onFocusChanged = { if (it.isFocused) viewModel.enableAutofocus() },
+                    focusRequester = focusRequester,
+                    autofocusEnabled = state.autofocusTextEnabled
                 )
 
                 is Credential.Phone -> BorderedTextField(
@@ -124,7 +130,10 @@ fun CredentialEntryView(viewModel: SignupViewModel, state: SignUpState) {
                         onGo = {
                             viewModel.goToNameEntry()
                         }
-                    )
+                    ),
+                    onFocusChanged = { if (it.isFocused) viewModel.enableAutofocus() },
+                    focusRequester = focusRequester,
+                    autofocusEnabled = state.autofocusTextEnabled
                 )
             }
         }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/SignupViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/SignupViewModel.kt
@@ -19,6 +19,7 @@ data class SignUpState(
     val isPhoneValid: Boolean = false,
     val canGoToNextScreen: Boolean = false,
     val credential: Credential = Credential.Email(),
+    val autofocusTextEnabled: Boolean = false
 )
 
 sealed class Credential {
@@ -78,6 +79,10 @@ class SignupViewModel(private val users: Users) : ViewModel() {
 
     fun updateCredentialType(updatedCredential: Credential) {
         _state.value = _state.value?.copy(credential = updatedCredential)
+    }
+
+    fun enableAutofocus() {
+        _state.value = _state.value?.copy(autofocusTextEnabled = true)
     }
 
     fun goToNameEntry() {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/BorderedTextField.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/BorderedTextField.kt
@@ -12,7 +12,12 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.dp
@@ -25,7 +30,10 @@ fun BorderedTextField(
     onValueChange: (String) -> Unit,
     placeholder: @Composable (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    keyboardActions: KeyboardActions = KeyboardActions()
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    onFocusChanged: ((FocusState) -> Unit) = {},
+    focusRequester: FocusRequester = FocusRequester.Default,
+    autofocusEnabled: Boolean = false
 ) {
     Box(
         modifier = Modifier
@@ -38,7 +46,10 @@ fun BorderedTextField(
 
     ) {
         TextField(
-            modifier = Modifier.padding(8.dp),
+            modifier = Modifier
+                .padding(8.dp)
+                .focusRequester(focusRequester)
+                .onFocusChanged(onFocusChanged),
             value = value,
             onValueChange = onValueChange,
             placeholder = placeholder,
@@ -50,5 +61,11 @@ fun BorderedTextField(
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions
         )
+    }
+
+    LaunchedEffect(Unit) {
+        if (autofocusEnabled) {
+            focusRequester.requestFocus()
+        }
     }
 }


### PR DESCRIPTION
fixes #695 

criteria:
- keyboard shows upon user clicking the phone/email textfield
- if keyboard is currently open, clicking the phone/email button keeps the keyboard open
- if keyboard is currently closed but has previously been opened, clicking the phone/email button re-opens the keyboard
- if keyboard is currently closed and has never been opened, clicking the phone/email button does not open the keyboard