### PR TITLE
Made recapturing easier without leaving TreeCaptureScreen

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -109,7 +109,9 @@ fun TreeCaptureScreen(
                 dialogIcon = painterResource(id = R.drawable.error_outline),
                 title = stringResource(R.string.poor_gps_header),
                 textContent = stringResource(R.string.poor_gps_message),
-                onPositiveClick = { navController.popBackStack() },
+                onPositiveClick = {
+                    viewModel.updateBadGpsDialogState(null)
+                },
                 onNegativeClick = {
                     navController.navigate(NavRoute.Dashboard.route) {
                         popUpTo(NavRoute.Dashboard.route) { inclusive = true }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
@@ -44,6 +44,10 @@ class TreeCaptureViewModel(
         }
     }
 
+    fun updateBadGpsDialogState(state: Boolean?){
+        _state.value = _state.value?.copy(isLocationAvailable = state)
+    }
+
     suspend fun endSession() {
         locationDataCapturer.stopGpsUpdates()
         sessionTracker.endSession()


### PR DESCRIPTION
Made recapturing easier without leaving TreeCaptureScreen. Previously clicking the positive approval button takes you back to the walletSelectScreen instead. fixes #795 