### PR TITLE
Removed escaped characters from extra_attributes and renamed field

### DIFF
--- a/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/8.json
+++ b/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/8.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 8,
-    "identityHash": "7c845efe1c7e5ddb54a1a68dceb3abc9",
+    "identityHash": "23d5e66afb3158086a80439d1257f3a2",
     "entities": [
       {
         "tableName": "planter_check_in",
@@ -714,7 +714,7 @@
       },
       {
         "tableName": "tree",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `photo_path` TEXT, `photo_url` TEXT, `note` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT DEFAULT NULL, `extra_data` TEXT DEFAULT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `session`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `photo_path` TEXT, `photo_url` TEXT, `note` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT DEFAULT NULL, `extra_attributes` TEXT DEFAULT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `session`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
         "fields": [
           {
             "fieldPath": "uuid",
@@ -778,8 +778,8 @@
             "defaultValue": "NULL"
           },
           {
-            "fieldPath": "extraData",
-            "columnName": "extra_data",
+            "fieldPath": "extraAttributes",
+            "columnName": "extra_attributes",
             "affinity": "TEXT",
             "notNull": false,
             "defaultValue": "NULL"
@@ -835,7 +835,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7c845efe1c7e5ddb54a1a68dceb3abc9')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '23d5e66afb3158086a80439d1257f3a2')"
     ]
   }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/TreeCaptureRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/TreeCaptureRequest.kt
@@ -24,5 +24,5 @@ class TreeCaptureRequest(
     @SerializedName("rotation_matrix")
     val rotationMatrix: String?,
     @SerializedName("extra_attributes")
-    val extraData: String,
+    val extraAttributes: String,
 )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import org.greenstand.android.TreeTracker.database.entity.LocationEntity
 import org.greenstand.android.TreeTracker.database.entity.SessionEntity
 import org.greenstand.android.TreeTracker.database.entity.TreeEntity
@@ -33,6 +34,7 @@ import org.greenstand.android.TreeTracker.database.legacy.entity.TreeCaptureEnti
         AutoMigration(from = 7, to = 8)
     ],
 )
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun treeTrackerDao(): TreeTrackerDAO

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TypeConverters.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TypeConverters.kt
@@ -1,0 +1,19 @@
+package org.greenstand.android.TreeTracker.database
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+
+object Converters {
+
+    val gson = Gson()
+
+    @TypeConverter
+    fun jsonToMap(value: String?): Map<String, String>? {
+        return gson.fromJson(value, Map::class.java) as? Map<String, String>
+    }
+
+    @TypeConverter
+    fun mapToJson(map: Map<String, String>?): String? {
+        return gson.toJson(map)
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/TreeEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/TreeEntity.kt
@@ -37,8 +37,8 @@ data class TreeEntity(
     var createdAt: Long,
     @ColumnInfo(name = "bundle_id", defaultValue = "NULL")
     var bundleId: String? = null,
-    @ColumnInfo(name = "extra_data", defaultValue = "NULL")
-    var extraData: String? = null,
+    @ColumnInfo(name = "extra_attributes", defaultValue = "NULL")
+    var extraAttributes: Map<String, String>? = null,
 ) {
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeUploader.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeUploader.kt
@@ -151,7 +151,7 @@ class TreeUploader(
                 stepCount = null,
                 deltaStepCount = null,
                 rotationMatrix = null,
-                extraData = gson.toJson(tree.extraData)
+                extraAttributes = gson.toJson(tree.extraAttributes)
             )
         }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateTreeUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/CreateTreeUseCase.kt
@@ -30,7 +30,7 @@ class CreateTreeUseCase(
             longitude = params.meanLongitude,
             latitude = params.meanLatitude,
             createdAt = time,
-            extraData = gson.toJson(params.treeCaptureAttributes()),
+            extraAttributes = params.treeCaptureAttributes(),
         )
 
         Timber.d("Inserting TreeCapture entity $entity")


### PR DESCRIPTION
resolves https://github.com/Greenstand/treetracker-android/issues/793

Room DB was adding escaped characters. Adding a converter for a Map fixes this, and now allows us to store Maps in the database.