### PR TITLE
Update progress bar for edge cases

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -134,9 +134,12 @@ fun TreeCaptureScreen(
             leftAction = {
                 UserImageButton(
                     onClick = {
-                        navController.navigate(NavRoute.UserSelect.route) {
-                            popUpTo(NavRoute.Dashboard.route)
-                            launchSingleTop = true
+                        scope.launch {
+                            viewModel.endSession()
+                            navController.navigate(NavRoute.UserSelect.route) {
+                                popUpTo(NavRoute.Dashboard.route)
+                                launchSingleTop = true
+                            }
                         }
                     },
                     imagePath = state.profilePicUrl

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelect.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelect.kt
@@ -66,7 +66,10 @@ fun UserSelect(
                         isLeft = true,
                         colors = navigationButtonColors,
                         onClick = {
-                            navController.popBackStack()
+                            navController.navigate(NavRoute.Dashboard.route) {
+                                popUpTo(NavRoute.Dashboard.route) { inclusive = true }
+                                launchSingleTop = true
+                            }
                         }
                     )
                 }


### PR DESCRIPTION
fixes https://github.com/Greenstand/treetracker-android/issues/799

UserSelect screen went back to dashboard by popping backstack which avoided a dashbaord refresh. It was fixed by navigating to it instead of popping backstack. This is not ideal, but it works for now, and I don't see other issues due to it.