### PR TITLE
Add location to new users and add walletId to request object

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/WalletRegistrationRequest.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/api/models/requests/WalletRegistrationRequest.kt
@@ -3,6 +3,8 @@ package org.greenstand.android.TreeTracker.api.models.requests
 import com.google.gson.annotations.SerializedName
 
 data class WalletRegistrationRequest(
+    @SerializedName("originating_wallet_registration_id")
+    val walletId: String,
     @SerializedName("wallet")
     val wallet: String,
     @SerializedName("user_photo_url")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardViewModel.kt
@@ -14,6 +14,7 @@ import org.greenstand.android.TreeTracker.analytics.Analytics
 import org.greenstand.android.TreeTracker.background.SyncNotificationManager
 import org.greenstand.android.TreeTracker.background.TreeSyncWorker
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
+import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
 
 data class DashboardState(
     val treesSynced: Int = 0,
@@ -25,9 +26,13 @@ class DashboardViewModel(
     private val dao: TreeTrackerDAO,
     private val workManager: WorkManager,
     private val analytics: Analytics,
-    private val syncNotification: SyncNotificationManager,
     private val treesToSyncHelper: TreesToSyncHelper,
+    locationDataCapturer: LocationDataCapturer,
 ) : ViewModel() {
+
+    init {
+        locationDataCapturer.stopGpsUpdates()
+    }
 
     private val _state = MutableLiveData<DashboardState>()
     val state: LiveData<DashboardState> = _state

--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
@@ -69,7 +69,7 @@ val appModule = module {
 
     viewModel { OrgPickerViewModel(get()) }
 
-    viewModel { UserSelectViewModel(get()) }
+    viewModel { UserSelectViewModel(get(), get()) }
 
     viewModel { org.greenstand.android.TreeTracker.signup.SignupViewModel(get(), get()) }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/PlanterUploader.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/PlanterUploader.kt
@@ -122,6 +122,7 @@ class PlanterUploader(
         val walletRegistrations = usersToUpload
             .map { user ->
                 WalletRegistrationRequest(
+                    walletId = user.uuid,
                     wallet = user.wallet,
                     firstName = user.firstName,
                     lastName = user.lastName,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturer.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturer.kt
@@ -35,6 +35,7 @@ class LocationDataCapturer(
     var currentConvergence: Convergence? = null
         private set
     private var convergenceStatus: ConvergenceStatus? = null
+    private var areLocationUpdatesOn: Boolean = false
 
     private val locationObserver: Observer<Location?> = Observer { location ->
         location?.apply {
@@ -112,13 +113,21 @@ class LocationDataCapturer(
     }
 
     fun startGpsUpdates() {
+        if (areLocationUpdatesOn) {
+            return
+        }
         locationUpdateManager.startLocationUpdates()
         locationUpdateManager.locationUpdateLiveData.observeForever(locationObserver)
+        areLocationUpdatesOn = true
     }
 
     fun stopGpsUpdates() {
+        if (!areLocationUpdatesOn) {
+            return
+        }
         locationUpdateManager.locationUpdateLiveData.removeObserver(locationObserver)
         locationUpdateManager.stopLocationUpdates()
+        areLocationUpdatesOn = false
     }
 
     /**

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectViewModel.kt
@@ -8,6 +8,7 @@ import java.util.Collections.emptyList
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.greenstand.android.TreeTracker.models.Users
+import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.user.User
 
 data class UserSelectState(
@@ -15,12 +16,16 @@ data class UserSelectState(
     val selectedUser: User? = null,
 )
 
-class UserSelectViewModel(users: Users) : ViewModel() {
+class UserSelectViewModel(
+    users: Users,
+    locationDataCapturer: LocationDataCapturer,
+) : ViewModel() {
 
     private val _state = MutableLiveData<UserSelectState>()
     val state: LiveData<UserSelectState> = _state
 
     init {
+        locationDataCapturer.startGpsUpdates()
         users.users()
             .onEach { userList ->
                 _state.value = UserSelectState(users = userList)


### PR DESCRIPTION
- Adds wallet UUID to wallet bundle object
- Starts location updates when enter user select screen. This allows location to be applied to wallet account.
- Starting location updates sooner should also help make the first tree capture convergence time shorter.
