### PR TITLE
return appropriate response when upload process fails

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/background/TreeSyncWorker.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/background/TreeSyncWorker.kt
@@ -25,8 +25,8 @@ class TreeSyncWorker(
 
     override suspend fun doWork(): Result {
         setForeground(syncNotificationManager.createForegroundInfo(applicationContext, id))
-        syncDataBundleUseCase.execute(Unit)
-        return Result.success()
+        val result = syncDataBundleUseCase.execute(Unit)
+        return if (result) Result.success() else Result.failure()
     }
 
     companion object {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardViewModel.kt
@@ -73,10 +73,17 @@ class DashboardViewModel(
 
                 _isSyncing = false
             }
-            State.CANCELLED,
-            State.FAILED -> {
+            State.CANCELLED -> {
+
                 if (_isSyncing != null) {
                     showSnackBar?.invoke(R.string.sync_stopped)
+                }
+
+                _isSyncing = false
+            }
+            State.FAILED -> {
+                if (_isSyncing != null) {
+                    showSnackBar?.invoke(R.string.sync_failed)
                 }
 
                 _isSyncing = false
@@ -146,7 +153,6 @@ class DashboardViewModel(
     private fun startDataSynchronization() {
         val request = OneTimeWorkRequestBuilder<TreeSyncWorker>()
             .setBackoffCriteria(BackoffPolicy.LINEAR, 1, TimeUnit.SECONDS)
-            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         workManager.enqueueUniqueWork(TreeSyncWorker.UNIQUE_WORK_ID, ExistingWorkPolicy.KEEP, request)


### PR DESCRIPTION
The change  addresses where failures during upload process doesn't return an appropriate error message to the UI.  For e.g. when a network error or other errors occurs, currently the upload process shows sync process stopped  instead of saying a error has occurred. 