### PR TITLE
Apply old image rotation logic

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/Camera.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/Camera.kt
@@ -2,20 +2,19 @@ package org.greenstand.android.TreeTracker.camera
 
 import android.util.DisplayMetrics
 import android.util.Size
-import androidx.camera.core.*
+import androidx.camera.core.AspectRatio
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.utilities.ImageUtils
 import timber.log.Timber
 import java.io.File
@@ -87,6 +86,7 @@ fun Camera(
                             object : ImageCapture.OnImageSavedCallback {
                                 override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
                                     ImageUtils.resizeImage(file.absolutePath, isSelfieMode)
+                                    ImageUtils.orientImage(file.absolutePath)
                                     Timber.tag("CameraXApp")
                                         .d("Photo capture succeeded: ${file.absolutePath}")
                                     onImageCaptured(file)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
@@ -8,15 +8,15 @@ import android.graphics.Matrix
 import android.util.Base64
 import androidx.exifinterface.media.ExifInterface
 import com.amazonaws.util.IOUtils
+import timber.log.Timber
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.*
 import kotlin.math.abs
 import kotlin.math.ceil
-import timber.log.Timber
 
 object ImageUtils {
 
@@ -394,6 +394,7 @@ object ImageUtils {
         val fileOutputStream = FileOutputStream(path)
         byteArrayBitmapStream.writeTo(fileOutputStream)
     }
+
     fun flip(src: Bitmap): Bitmap? {
         // create new matrix for transformation
         val matrix = Matrix()
@@ -404,7 +405,6 @@ object ImageUtils {
     }
 
     fun base64Image(path: String): String {
-
         /* There isn't enough memory to open up more than a couple camera photos */
         /* So pre-scale the target bitmap into which the file is decoded */
 
@@ -454,5 +454,58 @@ object ImageUtils {
         encodedImage = Base64.encodeToString(b, Base64.DEFAULT)
 
         return encodedImage
+    }
+
+    fun orientImage(photoPath: String) {
+        /* Get the size of the image */
+        val bmOptions = BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+        BitmapFactory.decodeFile(photoPath, bmOptions)
+
+        val exif: ExifInterface = try {
+            ExifInterface(photoPath)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return
+        }
+
+        val orientationString = exif.getAttribute(ExifInterface.TAG_ORIENTATION)
+        val orientation = if (orientationString != null) {
+            Integer.parseInt(orientationString)
+        } else {
+            ExifInterface.ORIENTATION_NORMAL
+        }
+        val rotationAngle = when(orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> 90
+            ExifInterface.ORIENTATION_ROTATE_180 -> 180
+            ExifInterface.ORIENTATION_ROTATE_270 -> 270
+            else -> 0
+        }
+
+        val matrix = Matrix().apply {
+            setRotate(
+                rotationAngle.toFloat(),
+                bmOptions.outWidth.toFloat() / 2,
+                bmOptions.outHeight.toFloat() / 2)
+        }
+
+        val rotatedBitmap = Bitmap.createBitmap(
+            BitmapFactory.decodeFile(photoPath),
+            0,
+            0,
+            bmOptions.outWidth,
+            bmOptions.outHeight,
+            matrix,
+            true)
+
+        val compressionQuality = 70
+        val byteArrayBitmapStream = ByteArrayOutputStream()
+        rotatedBitmap.compress(
+            Bitmap.CompressFormat.JPEG, compressionQuality,
+            byteArrayBitmapStream
+        )
+        val fileOutputStream = FileOutputStream(photoPath)
+        byteArrayBitmapStream.writeTo(fileOutputStream)
     }
 }


### PR DESCRIPTION
This SHOULD fix the image rotation. But it cannot be confirmed until we test it on devices with the image rotation bug. We can merge and push it to beta. Once it's confirmed by testers with image issues to be fixed, we can close the task.

This solution is not optimal since we are rotating the image twice... once in resize function, then again in orient function. Ideally we'd modify the image completely in one pass, but that can be optimized later.