### PR TITLE
update message api to properly support all types

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
@@ -35,6 +35,8 @@ import org.greenstand.android.TreeTracker.models.Users
 import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
 import org.greenstand.android.TreeTracker.models.location.LocationUpdateManager
 import org.greenstand.android.TreeTracker.models.messages.MessagesRepo
+import org.greenstand.android.TreeTracker.models.messages.network.MessageTypeDeserializer
+import org.greenstand.android.TreeTracker.models.messages.network.responses.MessageType
 import org.greenstand.android.TreeTracker.orgpicker.OrgPickerViewModel
 import org.greenstand.android.TreeTracker.permissions.PermissionViewModel
 import org.greenstand.android.TreeTracker.preferences.Preferences
@@ -144,7 +146,12 @@ val appModule = module {
 
     single { Configuration(get(), get()) }
 
-    single { GsonBuilder().serializeNulls().create() }
+    single {
+        GsonBuilder()
+            .registerTypeAdapter(MessageType::class.java, MessageTypeDeserializer())
+            .serializeNulls()
+            .create()
+    }
 
     single { TreeTrackerViewModelFactory() }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/NetworkModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/NetworkModule.kt
@@ -7,7 +7,7 @@ import retrofit2.Retrofit
 
 val networkModule = module {
 
-    single { RetrofitBuilder().create() }
+    single { RetrofitBuilder(get()).create() }
 
     single { get<Retrofit>().create(MessagesApiService::class.java) }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/Data.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/Data.kt
@@ -7,14 +7,22 @@ interface Message {
     val composedAt: String
 }
 
-data class TextMessage(
+data class DirectMessage(
+    override val id: String,
+    override val from: String,
+    override val to: String,
+    override val composedAt: String,
+    val parentMessageId: String?,
+    val body: String,
+) : Message
+
+data class AnnouncementMessage(
     override val id: String,
     override val from: String,
     override val to: String,
     override val composedAt: String,
     val subject: String,
-    val body: String,
-    val parentMessageId: String?,
+    val body: String?,
 ) : Message
 
 data class SurveyMessage(
@@ -23,7 +31,15 @@ data class SurveyMessage(
     override val to: String,
     override val composedAt: String,
     val questions: List<Question>,
-    val answers: List<String>,
+) : Message
+
+data class SurveyResponseMessage(
+    override val id: String,
+    override val from: String,
+    override val to: String,
+    override val composedAt: String,
+    val questions: List<Question>,
+    val responses: List<String>,
 ) : Message
 
 data class Question(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/MessagesRepo.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/MessagesRepo.kt
@@ -4,6 +4,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.greenstand.android.TreeTracker.models.messages.network.MessagesApiService
 
+/**
+ * For test data, use 'handle3' as a wallet
+ */
 class MessagesRepo(private val apiService: MessagesApiService) {
 
     suspend fun getMessages(wallet: String): List<Message> = withContext(Dispatchers.IO) {
@@ -11,12 +14,12 @@ class MessagesRepo(private val apiService: MessagesApiService) {
         return@withContext result.messages.map { it.toMessage() }
     }
 
-    suspend fun getTextMessages(
+    suspend fun getDirectMessages(
         wallet: String,
         from: String,
-        to: String): List<TextMessage> = withContext(Dispatchers.IO) {
+        to: String): List<DirectMessage> = withContext(Dispatchers.IO) {
         return@withContext getMessages(wallet)
-            .filterIsInstance<TextMessage>()
+            .filterIsInstance<DirectMessage>()
             .filter { (it.from == from || it.from == to) && (it.to == to || it.to == from) }
             .sortedBy { it.composedAt }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/NetworkToData.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/NetworkToData.kt
@@ -1,2 +1,0 @@
-package org.greenstand.android.TreeTracker.models.messages
-

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/MessageTypeDeserializer.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/MessageTypeDeserializer.kt
@@ -1,0 +1,20 @@
+package org.greenstand.android.TreeTracker.models.messages.network
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import org.greenstand.android.TreeTracker.models.messages.network.responses.MessageType
+import java.lang.reflect.Type
+
+class MessageTypeDeserializer: JsonDeserializer<MessageType> {
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): MessageType {
+        return when(json.asString) {
+            "message" -> MessageType.MESSAGE
+            "announce" -> MessageType.ANNOUNCE
+            "survey" -> MessageType.SURVEY
+            "survey_response" -> MessageType.SURVEY_RESPONSE
+            else -> throw IllegalArgumentException("Message type unknown.")
+        }
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/MessagesApiService.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/MessagesApiService.kt
@@ -7,6 +7,6 @@ import retrofit2.http.Query
 interface MessagesApiService {
 
     @GET("messaging/message")
-    suspend fun getMessages(@Query("author_handle") wallet: String): MessagesResponse
+    suspend fun getMessages(@Query("handle") wallet: String): MessagesResponse
 
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/RetrofitBuilder.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/RetrofitBuilder.kt
@@ -1,11 +1,12 @@
 package org.greenstand.android.TreeTracker.models.messages.network
 
+import com.google.gson.Gson
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-class RetrofitBuilder {
+class RetrofitBuilder(private val gson: Gson) {
 
     fun create(): Retrofit {
         return Retrofit.Builder()
@@ -15,7 +16,7 @@ class RetrofitBuilder {
                     .also { it.setLevel(HttpLoggingInterceptor.Level.BODY) })
                 .build())
             .baseUrl(BASE_ENDPOINT)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
     }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/MessageResponse.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/MessageResponse.kt
@@ -4,15 +4,18 @@ import com.google.gson.annotations.SerializedName
 
 data class MessageResponse(
     val id: String,
+    val type: MessageType,
     val from: String,
     val to: String,
-    val subject: String,
-    val body: String,
+    val subject: String?,
+    val body: String?,
     @SerializedName("composed_at")
     val composedAt: String,
     @SerializedName("parent_message_id")
     val parentMessageId: String?,
     @SerializedName("video_link")
     val videoLink: String?,
-    val survey: SurveyResponse,
+    @SerializedName("survey_response")
+    val surveyResponse: List<String>?,
+    val survey: SurveyResponse?,
 )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/MessageType.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/MessageType.kt
@@ -1,0 +1,8 @@
+package org.greenstand.android.TreeTracker.models.messages.network.responses
+
+enum class MessageType {
+    MESSAGE,
+    ANNOUNCE,
+    SURVEY,
+    SURVEY_RESPONSE,
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/QuestionResponse.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/QuestionResponse.kt
@@ -1,6 +1,6 @@
 package org.greenstand.android.TreeTracker.models.messages.network.responses
 
 data class QuestionResponse(
-    val prompt: String?,
-    val choices: List<String>?,
+    val prompt: String,
+    val choices: List<String>,
 )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/SurveyResponse.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/messages/network/responses/SurveyResponse.kt
@@ -1,9 +1,8 @@
 package org.greenstand.android.TreeTracker.models.messages.network.responses
 
 class SurveyResponse(
-    val id: String?,
-    val title: String?,
+    val id: String,
+    val title: String,
     val response: Boolean,
     val questions: List<QuestionResponse>,
-    val answers: List<String?>,
 )


### PR DESCRIPTION
WIP

Contains 4 message types:

DirectMessage (1 on 1 messages to another person)
AnnouncementMessage (notifies user of something, can be replied to by a DirectMessage)
SurveyMessage (shows survey to user)
SurveyResponseMessage (the users answers to a SurveyMessage)

example json tested on:
https://dev-k8s.treetracker.org/messaging/message?handle=admin
https://dev-k8s.treetracker.org/messaging/message?handle=handle3