### PR TITLE
Show only one message per chat thread in message list screen

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/individualmeassagelist/IndividualMessageListViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/individualmeassagelist/IndividualMessageListViewModel.kt
@@ -7,8 +7,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.models.Users
+import org.greenstand.android.TreeTracker.models.messages.AnnouncementMessage
+import org.greenstand.android.TreeTracker.models.messages.DirectMessage
 import org.greenstand.android.TreeTracker.models.messages.Message
 import org.greenstand.android.TreeTracker.models.messages.MessagesRepo
+import org.greenstand.android.TreeTracker.models.messages.SurveyMessage
 import org.greenstand.android.TreeTracker.models.user.User
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -32,9 +35,26 @@ class IndividualMessageListViewModel(
         viewModelScope.launch {
             val currentUser = users.getUser(userId)
             val messages = messagesRepo.getMessages(currentUser!!.wallet)
+
+            // get list of senders to pick out one message per chat
+            val externalChatMessages = messages
+                .filterIsInstance<DirectMessage>()
+                .sortedBy { it.composedAt }
+                .filter { it.from != currentUser.wallet }
+                .groupBy { it.from }
+
+            // Get all types of messages to show
+            val chatsToShow = externalChatMessages.keys.map { externalChatMessages[it]!!.first() }
+            val surveysToShow = messages.filterIsInstance<SurveyMessage>()
+            val announcementsToShow = messages.filterIsInstance<AnnouncementMessage>()
+
+            // Merge messages together and sort by newest
+            val messagesToShow = (chatsToShow + surveysToShow + announcementsToShow)
+                .sortedBy { it.composedAt }
+
             _state.value = IndividualMessageListState(
                 currentUser = currentUser,
-                messages = messages,
+                messages = messagesToShow,
             )
         }
     }


### PR DESCRIPTION
Before:
Showed each individual chat message as a new item

Now:
Each chat thread shows as a single item