### PR TITLE
modified design and added log to show the scope bug

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
@@ -3,25 +3,31 @@ package org.greenstand.android.TreeTracker.signup
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
 import androidx.compose.material.Scaffold
 import androidx.compose.material.SnackbarHostState
 import androidx.compose.material.Text
@@ -34,6 +40,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -153,6 +160,55 @@ fun CredentialEntryView(viewModel: SignupViewModel, state: SignUpState) {
 
             ViewWebMapText(isVisible = state.isInternetAvailable, onClick = navigateToWebPage)
 
+
+            Spacer(modifier = Modifier.height(30.dp))
+            Box(
+                modifier = Modifier
+                    .background(color = AppColors.Green)
+                    .padding(10.dp)
+                    .wrapContentSize()
+                    .clickable {
+                        Log.d(
+                            "scope_bug",
+                            "clickable " + "email " + state.email + " phone " + state.phone
+                        )
+                    }
+            ){
+                Text(
+                    text = "on Click handled from clickable",
+                    color = CustomTheme.textColors.darkText,
+                    )
+            }
+            Spacer(modifier = Modifier.height(30.dp))
+            Box(
+                modifier = Modifier
+                    .background(color = AppColors.Green)
+                    .padding(10.dp)
+                    .wrapContentSize()
+                    .pointerInput(true) {
+                        detectTapGestures(
+                            onTap = {
+                                Log.d(
+                                    "scope_bug",
+                                    "detect tap gestures(on tap) " + "email " + state.email + " phone " + state.phone
+                                )
+
+                            },
+                            onPress = {
+                                Log.d(
+                                    "scope_bug",
+                                    "detect tap gestures (Pressed) " + "email " + state.email + " phone " + state.phone
+                                )
+
+                            }
+                        )
+                    }
+            ){
+                Text(
+                    text = "on Click handled from tap gestures",
+                    color = CustomTheme.textColors.darkText,
+                    )
+            }
             CustomSnackbar(snackbarHostState = snackBarHostState, backGroundColor = AppColors.Red)
         }
         if (state.showPrivacyDialog == true) {


### PR DESCRIPTION
modified design and added log to show the scope bug. Clickable events can be handled in Modifier.clickable{} or Modifier.pointerInput(true) { detectTapGestures(... To describe the bug I created two buttons that handle events in both ways and logs the current value. For the first one it shows the current value but for the second approach it keeps using the default value. The onClick events in the depth buttons are handled in the second approach which is why the arrow button fails to validate except by keyboard and other issues discussed here #984 