### PR TITLE
Fix DepthButton scope bug

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/TextButton.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/TextButton.kt
@@ -396,7 +396,7 @@ fun DepthButton(
     content: @Composable (BoxScope.() -> Unit),
 ) {
     val contentColor by colors.contentColor(isEnabled)
-
+    val onClickState = rememberUpdatedState(onClick)
     var isPressed by remember { mutableStateOf(false) }
     isSelected?.let { isPressed = isSelected }
 
@@ -415,7 +415,7 @@ fun DepthButton(
                     if (!isEnabled) return@pointerInput
                     detectTapGestures(
                         onTap = {
-                            onClick()
+                            onClickState.value.invoke()
                         },
                         onPress = {
                             isPressed = true


### PR DESCRIPTION
The lambda was not being recreated which resulted in the first onClick which has no data in it being used.

Putting the onClick in a state object fixed it. This is how it's done in the Clickable.kt