### PR TITLE
Use shared scoped data for capture setup flow

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/di/AppModule.kt
@@ -39,6 +39,9 @@ import org.greenstand.android.TreeTracker.models.messages.MessagesRepo
 import org.greenstand.android.TreeTracker.models.messages.network.MessageTypeDeserializer
 import org.greenstand.android.TreeTracker.models.messages.network.responses.MessageType
 import org.greenstand.android.TreeTracker.models.organization.OrgRepo
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupData
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScope
+import org.greenstand.android.TreeTracker.orgpicker.AddOrgViewModel
 import org.greenstand.android.TreeTracker.orgpicker.OrgPickerViewModel
 import org.greenstand.android.TreeTracker.permissions.PermissionViewModel
 import org.greenstand.android.TreeTracker.preferences.Preferences
@@ -56,12 +59,16 @@ import org.greenstand.android.TreeTracker.utilities.DeviceUtils
 import org.greenstand.android.TreeTracker.utilities.TimeProvider
 import org.greenstand.android.TreeTracker.viewmodels.ConfigViewModel
 import org.greenstand.android.TreeTracker.walletselect.WalletSelectViewModel
+import org.greenstand.android.TreeTracker.walletselect.addwallet.AddWalletViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val appModule = module {
 
+    viewModel { AddWalletViewModel() }
+
+    viewModel { AddOrgViewModel(get(), get(), get(), get()) }
 
     viewModel { ConfigViewModel(get(), get()) }
 
@@ -189,4 +196,9 @@ val appModule = module {
     factory { TreeUploader(get(), get(), get(), get(), get()) }
 
     factory { SyncDataUseCase(get(), get(), get(), get(), get(), get(), get()) }
+
+    scope<CaptureSetupScope> {
+        scoped { CaptureSetupData() }
+    }
+
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/NavRoute.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/NavRoute.kt
@@ -82,50 +82,30 @@ sealed class NavRoute {
 
     object WalletSelect : NavRoute() {
         override val content: @Composable (NavBackStackEntry) -> Unit = {
-            WalletSelectScreen(getPlanterInfoId(it))
+            WalletSelectScreen()
         }
-        override val route: String = "wallet-select/{planterInfoId}"
-        override val arguments = listOf(navArgument("planterInfoId") { type = NavType.LongType })
+        override val route: String = "wallet-select"
 
-        private fun getPlanterInfoId(backStackEntry: NavBackStackEntry): Long {
-            return backStackEntry.arguments?.getLong("planterInfoId") ?: -1
-        }
-
-        fun create(planterInfoId: Long) = "wallet-select/$planterInfoId"
+        fun create() = route
     }
 
     object AddWallet : NavRoute() {
         override val content: @Composable (NavBackStackEntry) -> Unit = {
-            AddWalletScreen(getPlanterInfoId(it))
+            AddWalletScreen()
         }
         override val route: String = "add-wallet/{planterInfoId}"
-        override val arguments = listOf(navArgument("planterInfoId") { type = NavType.LongType })
 
-        private fun getPlanterInfoId(backStackEntry: NavBackStackEntry): Long {
-            return backStackEntry.arguments?.getLong("planterInfoId") ?: -1
-        }
 
-        fun create(planterInfoId: Long) = "add-wallet/$planterInfoId"
+        fun create() = route
     }
 
     object AddOrg : NavRoute() {
         override val content: @Composable (NavBackStackEntry) -> Unit = {
-            AddOrgScreen(getPlanterInfoId(it), getDestinationWallet(it))
+            AddOrgScreen()
         }
-        override val route: String = "add-org/{planterInfoId}/{destinationWallet}"
-        override val arguments = listOf(
-            navArgument("planterInfoId") { type = NavType.LongType },
-            navArgument("destinationWallet") { type = NavType.StringType })
+        override val route: String = "add-org"
 
-        private fun getPlanterInfoId(backStackEntry: NavBackStackEntry): Long {
-            return backStackEntry.arguments?.getLong("planterInfoId") ?: -1
-        }
-
-        private fun getDestinationWallet(backStackEntry: NavBackStackEntry): String {
-            return backStackEntry.arguments?.getString("destinationWallet") ?: ""
-        }
-
-        fun create(planterInfoId: Long, destinationWallet: String) = "add-org/$planterInfoId/$destinationWallet"
+        fun create() = route
     }
 
     object Selfie : NavRoute() {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeTrackerViewModelFactory.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeTrackerViewModelFactory.kt
@@ -6,9 +6,10 @@ import org.greenstand.android.TreeTracker.capture.TreeImageReviewViewModel
 import org.greenstand.android.TreeTracker.dashboard.DashboardViewModel
 import org.greenstand.android.TreeTracker.languagepicker.LanguagePickerViewModel
 import org.greenstand.android.TreeTracker.messages.individualmeassagelist.IndividualMessageListViewModel
+import org.greenstand.android.TreeTracker.orgpicker.AddOrgViewModel
 import org.greenstand.android.TreeTracker.orgpicker.OrgPickerViewModel
-import org.greenstand.android.TreeTracker.signup.SignupViewModel
 import org.greenstand.android.TreeTracker.permissions.PermissionViewModel
+import org.greenstand.android.TreeTracker.signup.SignupViewModel
 import org.greenstand.android.TreeTracker.splash.SplashScreenViewModel
 import org.greenstand.android.TreeTracker.treeheight.TreeHeightSelectionViewModel
 import org.greenstand.android.TreeTracker.userselect.UserSelectViewModel
@@ -34,6 +35,7 @@ class TreeTrackerViewModelFactory : ViewModelProvider.NewInstanceFactory(), Koin
             modelClass.isAssignableFrom(PermissionViewModel::class.java) -> get<PermissionViewModel>() as T
             modelClass.isAssignableFrom(IndividualMessageListViewModel::class.java) -> get<IndividualMessageListViewModel>() as T
             modelClass.isAssignableFrom(TreeHeightSelectionViewModel::class.java) -> get<TreeHeightSelectionViewModel>() as T
+            modelClass.isAssignableFrom(AddOrgViewModel::class.java) -> get<AddOrgViewModel>() as T
             else -> throw RuntimeException("Unable to create instance of ${modelClass.simpleName}. Did you forget to update the TreeTrackerViewModelFactory?")
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/setupflow/CaptureSetupData.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/setupflow/CaptureSetupData.kt
@@ -1,0 +1,10 @@
+package org.greenstand.android.TreeTracker.models.setupflow
+
+import org.greenstand.android.TreeTracker.models.user.User
+
+data class CaptureSetupData(
+    var user: User? = null,
+    var destinationWallet: String? = null,
+    var sessionNote: String? = null,
+    var organizationName: String? = null,
+)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/setupflow/SetupScope.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/setupflow/SetupScope.kt
@@ -1,0 +1,28 @@
+package org.greenstand.android.TreeTracker.models.setupflow
+
+
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.createScope
+import org.koin.core.scope.Scope
+
+object CaptureSetupScopeManager {
+
+    private var currentScope: Scope? = null
+
+    fun open() {
+        currentScope = CaptureSetupScope().scope
+        currentScope?.get<CaptureSetupData>()
+    }
+
+    fun getData(): CaptureSetupData = currentScope!!.get()
+
+    fun close() {
+        currentScope?.close()
+    }
+}
+
+class CaptureSetupScope : KoinScopeComponent {
+    override val scope: Scope by lazy {
+        createScope(this)
+    }
+}

--- a/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgScreen.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.theme.CustomTheme
 import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.ArrowButton
@@ -36,11 +37,7 @@ import org.greenstand.android.TreeTracker.view.BorderedTextField
 import org.greenstand.android.TreeTracker.view.DepthButton
 
 @Composable
-fun AddOrgScreen(
-    userId: Long,
-    destinationWallet: String,
-    viewModel: AddOrgViewModel = viewModel(factory = AddOrgViewModelFactory(userId, destinationWallet))
-) {
+fun AddOrgScreen(viewModel: AddOrgViewModel = viewModel(factory = LocalViewModelFactory.current)) {
     val navController = LocalNavHostController.current
     val scope = rememberCoroutineScope()
     val state by viewModel.state.observeAsState(AddOrgState())

--- a/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgViewModel.kt
@@ -3,18 +3,15 @@ package org.greenstand.android.TreeTracker.orgpicker
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.models.SessionTracker
 import org.greenstand.android.TreeTracker.models.StepCounter
-import org.greenstand.android.TreeTracker.models.UserRepo
 import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 import org.greenstand.android.TreeTracker.preferences.PrefKey
 import org.greenstand.android.TreeTracker.preferences.PrefKeys
 import org.greenstand.android.TreeTracker.preferences.Preferences
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 
 
 data class AddOrgState(
@@ -24,9 +21,6 @@ data class AddOrgState(
 )
 
 class AddOrgViewModel(
-    private val userId: Long,
-    private val destinationWallet: String,
-    private val userRepo: UserRepo,
     private val stepCounter: StepCounter,
     private val sessionTracker: SessionTracker,
     private val locationDataCapturer: LocationDataCapturer,
@@ -39,13 +33,14 @@ class AddOrgViewModel(
     init {
         viewModelScope.launch {
             _state.value = AddOrgState(
-                userImagePath = userRepo.getUser(userId)!!.photoPath,
+                userImagePath = CaptureSetupScopeManager.getData().user!!.photoPath,
                 previousOrgName = preferences.getString(PREV_ORG_KEY)
             )
         }
     }
 
     fun updateOrgName(orgName: String) {
+        CaptureSetupScopeManager.getData().organizationName = orgName
         _state.value = _state.value!!.copy(
             orgName = orgName
         )
@@ -62,25 +57,12 @@ class AddOrgViewModel(
             preferences.edit().putString(PREV_ORG_KEY, _state.value?.orgName).apply()
         }
         stepCounter.enable()
-        sessionTracker.startSession(
-            userId = userId,
-            destinationWallet = destinationWallet,
-            organization = _state.value!!.orgName
-        )
+        CaptureSetupScopeManager.getData().organizationName = _state.value?.orgName
+        sessionTracker.startSession()
         locationDataCapturer.startGpsUpdates()
     }
 
     companion object {
         private val PREV_ORG_KEY = PrefKeys.SYSTEM_SETTINGS + PrefKey("autofill-org")
-    }
-}
-
-class AddOrgViewModelFactory(
-    private val userId: Long,
-    private val destinationWallet: String)
-    : ViewModelProvider.Factory, KoinComponent {
-    @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return AddOrgViewModel(userId, destinationWallet, get(), get(), get(), get(), get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
@@ -309,7 +309,7 @@ fun ExistingUserDialog(
                     AppButtonColors.Default,
                     Green
                 ) {
-                    navController.navigate(NavRoute.WalletSelect.create(user.id)) {
+                    navController.navigate(NavRoute.WalletSelect.create()) {
                         popUpTo(NavRoute.SignupFlow.route) { inclusive = true }
                         launchSingleTop = true
                     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.activities.CaptureImageContract
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 import org.greenstand.android.TreeTracker.root.LocalNavHostController
 import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.ArrowButton
@@ -48,8 +49,9 @@ fun NameEntryView(viewModel: SignupViewModel, state: SignUpState) {
                         launchSingleTop = true
                     }
                 } else {
-                    // In tracking flow, clear login stack and go to wallet selection flow
-                    navController.navigate(NavRoute.WalletSelect.create(user.id)) {
+                    // In tracking setup flow, clear login stack and go to wallet selection flow
+                    CaptureSetupScopeManager.getData().user = user
+                    navController.navigate(NavRoute.WalletSelect.create()) {
                         popUpTo(NavRoute.SignupFlow.route) { inclusive = true }
                         launchSingleTop = true
                     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectScreen.kt
@@ -11,7 +11,7 @@ fun UserSelectScreen() {
         isCreateUserEnabled = true,
         isNotificationEnabled = true,
         onNextRoute = { user ->
-            NavRoute.WalletSelect.create(user.id)
+            NavRoute.WalletSelect.create()
         }
     )
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelectViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.greenstand.android.TreeTracker.models.UserRepo
 import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 import org.greenstand.android.TreeTracker.models.user.User
 import java.util.Collections.emptyList
 
@@ -25,6 +26,7 @@ class UserSelectViewModel(
     val state: LiveData<UserSelectState> = _state
 
     init {
+        CaptureSetupScopeManager.open()
         locationDataCapturer.startGpsUpdates()
         userRepo.users()
             .onEach { userList ->
@@ -34,6 +36,7 @@ class UserSelectViewModel(
     }
 
     fun selectUser(user: User) {
+        CaptureSetupScopeManager.getData().user = user
         _state.value = _state.value?.copy(
             selectedUser = user
         )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -2,19 +2,15 @@ package org.greenstand.android.TreeTracker.walletselect
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
@@ -42,15 +38,10 @@ import org.greenstand.android.TreeTracker.view.UserImageButton
 
 @Composable
 fun WalletSelectScreen(
-    planterInfoId: Long,
     viewModel: WalletSelectViewModel = viewModel(factory = LocalViewModelFactory.current)
 ) {
 
     val state by viewModel.state.observeAsState(initial = WalletSelectState())
-
-    LaunchedEffect(true) {
-        viewModel.loadPlanter(planterInfoId)
-    }
 
     val navController = LocalNavHostController.current
     val scope = rememberCoroutineScope()
@@ -81,10 +72,8 @@ fun WalletSelectScreen(
                         isEnabled = state.selectedUser != null
                     ) {
                         scope.launch {
-                            state.currentUser?.let { user ->
-                                navController.navigate(NavRoute.AddOrg.create(
-                                    state.currentUser!!.id,
-                                    state.selectedUser!!.wallet))
+                            state.currentUser?.let {
+                                navController.navigate(NavRoute.AddOrg.create())
                             }
                         }
                     }
@@ -92,7 +81,7 @@ fun WalletSelectScreen(
                 centerAction = {
                     OrangeAddButton(
                         modifier = Modifier.align(Alignment.Center),
-                        onClick = { navController.navigate(NavRoute.AddWallet.create(state.currentUser!!.id)) },
+                        onClick = { navController.navigate(NavRoute.AddWallet.create()) },
                     )
                 },
                 leftAction = {
@@ -135,7 +124,6 @@ fun WalletSelectScreen(
 fun WalletItem(user: User, isSelected: Boolean, onClick: (Long) -> Unit) {
 
     Row(
-        // contentPadding = PaddingValues(start = 8.dp, end = 8.dp, top = 10.dp),
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.models.UserRepo
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 import org.greenstand.android.TreeTracker.models.user.User
 
 data class WalletSelectState(
@@ -17,16 +18,14 @@ data class WalletSelectState(
     val selectedUser: User? = null,
 )
 
-class WalletSelectViewModel(
-    private val userRepo: UserRepo,
-) : ViewModel() {
+class WalletSelectViewModel(private val userRepo: UserRepo) : ViewModel() {
 
     private val _state = MutableLiveData<WalletSelectState>()
     val state: LiveData<WalletSelectState> = _state
 
-    fun loadPlanter(planterInfoId: Long) {
+    init {
         viewModelScope.launch {
-            val currentUser = userRepo.getUser(planterInfoId)
+            val currentUser = CaptureSetupScopeManager.getData().user
             userRepo.users()
                 .map { users -> users.filter { it.id != currentUser?.id } }
                 .onEach { users ->
@@ -43,8 +42,10 @@ class WalletSelectViewModel(
 
     fun selectPlanter(planterInfoId: Long) {
         viewModelScope.launch {
+            val selectedUser = userRepo.getUserList().find { planterInfoId == it.id }
+            CaptureSetupScopeManager.getData().destinationWallet = selectedUser?.wallet
             _state.value = _state.value?.copy(
-                selectedUser = userRepo.getUserList().find { planterInfoId == it.id }
+                selectedUser = selectedUser
             )
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletScreen.kt
@@ -25,14 +25,14 @@ import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.root.LocalNavHostController
+import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.view.ActionBar
 import org.greenstand.android.TreeTracker.view.ArrowButton
 import org.greenstand.android.TreeTracker.view.BorderedTextField
 
 @Composable
 fun AddWalletScreen(
-    userId: Long,
-    viewModel: AddWalletViewModel = viewModel(factory = AddWalletViewModelFactory(userId))
+    viewModel: AddWalletViewModel = viewModel(factory = LocalViewModelFactory.current)
 ) {
     val navController = LocalNavHostController.current
     val scope = rememberCoroutineScope()
@@ -52,7 +52,7 @@ fun AddWalletScreen(
                         isEnabled = state.walletName.isNotBlank()
                     ) {
                         scope.launch {
-                            navController.navigate(NavRoute.AddOrg.create(userId, state.walletName))
+                            navController.navigate(NavRoute.AddOrg.create())
                         }
                     }
                 }
@@ -79,7 +79,7 @@ fun AddWalletScreen(
                 keyboardActions = KeyboardActions(
                     onGo = {
                         scope.launch {
-                            navController.navigate(NavRoute.AddOrg.create(userId, state.walletName))
+                            navController.navigate(NavRoute.AddOrg.create())
                         }
                     }
                 )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletViewModel.kt
@@ -3,22 +3,16 @@ package org.greenstand.android.TreeTracker.walletselect.addwallet
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import org.greenstand.android.TreeTracker.models.UserRepo
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 
 data class AddWalletState(
     val walletName: String = "",
     val userImagePath: String = "",
 )
 
-class AddWalletViewModel(
-    private val userId: Long,
-    private val userRepo: UserRepo,
-) : ViewModel() {
+class AddWalletViewModel : ViewModel() {
 
     private val _state = MutableLiveData<AddWalletState>()
     val state: LiveData<AddWalletState> = _state
@@ -26,22 +20,15 @@ class AddWalletViewModel(
     init {
         viewModelScope.launch {
             _state.value = AddWalletState(
-                userImagePath = userRepo.getUser(userId)!!.photoPath
+                userImagePath = CaptureSetupScopeManager.getData().user!!.photoPath
             )
         }
     }
 
     fun updateWalletName(destinationWallet: String) {
+        CaptureSetupScopeManager.getData().destinationWallet = destinationWallet
         _state.value = _state.value!!.copy(
             walletName = destinationWallet
         )
-    }
-}
-
-class AddWalletViewModelFactory(private val userId: Long)
-    : ViewModelProvider.Factory, KoinComponent {
-    @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return AddWalletViewModel(userId, get()) as T
     }
 }


### PR DESCRIPTION
In order to allow screens to dynamically navigates to each other, we need a new way of passing data around.

This PR moves the data collection into a scoped object. The object is created when the user enters the capture setup flow, and is destroyed when the capture session starts.