### PR TITLE
Modified logic to always check if location is enabled for every tree capture

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/permissions/PermissionViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/permissions/PermissionViewModel.kt
@@ -8,13 +8,17 @@ import androidx.lifecycle.ViewModel
 data class PermissionItemsState(
     val isLocationEnabled: Boolean? = null
 )
-class PermissionViewModel (
-    private val locationManager: LocationManager) : ViewModel(){
+class PermissionViewModel(
+    private val locationManager: LocationManager
+) : ViewModel() {
 
-    private val _state = MutableLiveData(PermissionItemsState(isLocationEnabled = isLocationEnabled()))
+    private val _state =
+        MutableLiveData(PermissionItemsState())
     val state: LiveData<PermissionItemsState> = _state
 
-    private fun isLocationEnabled(): Boolean {
-        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+    fun isLocationEnabled(){
+        _state.value = _state.value?.copy(
+            isLocationEnabled = locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
+        )
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/permissions/Permissions.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/permissions/Permissions.kt
@@ -83,6 +83,7 @@ fun PermissionRequest(
             Manifest.permission.ACCESS_FINE_LOCATION -> {
                 when {
                     perm.hasPermission -> {
+                        viewModel.isLocationEnabled()
                         if (state.isLocationEnabled == false) {
                             enableLocation()
                         }
@@ -98,6 +99,7 @@ fun PermissionRequest(
             Manifest.permission.ACCESS_COARSE_LOCATION -> {
                 when {
                     perm.hasPermission -> {
+                        viewModel.isLocationEnabled()
                         if (state.isLocationEnabled == false) {
                             enableLocation()
                         }


### PR DESCRIPTION
This updates the app to check if location is enabled on every tree capture. Previously it was only checked on the initial capture and keeps redirecting the user back to turn on Locations. It is only apparent on physical device and not on emulator. fixes #974 