### PR TITLE
Activated Crashlytics for Production.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -259,7 +259,6 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:25.10.0')
     implementation 'com.google.firebase:firebase-analytics:18.0.2'
     implementation 'com.google.firebase:firebase-crashlytics-ktx:17.3.1'
-    implementation 'com.google.firebase:firebase-auth-ktx:20.0.2'
     implementation 'com.google.firebase:firebase-iid:21.0.1'
 
     testImplementation "io.mockk:mockk:1.10.0"


### PR DESCRIPTION
In the firebase project, the test app has a SHA fingerprint to it while the production app has no SHA fingerprint to it. SHA fingerprints are optional and only necessary for google authentication. I removed the firebase authentication dependency as it was not used at all in the projects and was also preventing apps in production from sending report to Crashlytics. I have tested and can now see crash reports for the production app with this change. Fixes #1026  