### PR TITLE
add tests for capture and orgpicker viewmodels

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -224,6 +224,10 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.3.2'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 
     //Database
@@ -262,6 +266,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-iid:21.0.1'
 
     testImplementation "io.mockk:mockk:1.10.0"
+    testImplementation "org.mockito:mockito-inline:3.11.2"
     testImplementation "junit:junit:4.13.1"
     testImplementation "androidx.room:room-testing:2.2.6"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -266,7 +266,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-iid:21.0.1'
 
     testImplementation "io.mockk:mockk:1.10.0"
-    testImplementation "org.mockito:mockito-inline:3.11.2"
     testImplementation "junit:junit:4.13.1"
     testImplementation "androidx.room:room-testing:2.2.6"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9"

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModel.kt
@@ -45,7 +45,7 @@ class TreeImageReviewViewModel(
 
     fun addNote(){
         viewModelScope.launch {
-            treeCapturer.setNote(_state.value!!.note)
+            _state.value?.note?.let { treeCapturer.setNote(it) }
             _state.value = _state.value?.copy(isDialogOpen = false)
         }
     }

--- a/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModelTest.kt
@@ -1,0 +1,136 @@
+package org.greenstand.android.TreeTracker.capture
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.greenstand.android.TreeTracker.MainCoroutineRule
+import org.greenstand.android.TreeTracker.models.SessionTracker
+import org.greenstand.android.TreeTracker.models.TreeCapturer
+import org.greenstand.android.TreeTracker.models.UserRepo
+import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
+import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesUseCase
+import org.greenstand.android.TreeTracker.utils.getOrAwaitValueTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import java.io.File
+import kotlin.math.exp
+
+@ExperimentalCoroutinesApi
+class TreeCaptureViewModelTest {
+
+    /*
+     Here the Rule runs coroutines on the main thread
+     */
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private val treeCapturer = Mockito.mock(TreeCapturer::class.java)
+    private val userRepo = Mockito.mock(UserRepo::class.java)
+    private val sessionTracker = Mockito.mock(SessionTracker::class.java)
+    private val createFakeTreesUseCase = Mockito.mock(CreateFakeTreesUseCase::class.java)
+    private val locationDataCapturer = Mockito.mock(LocationDataCapturer::class.java)
+
+    private lateinit var treeCaptureViewModel: TreeCaptureViewModel
+
+    /*
+     Setting the main dispatcher to Dispatcher.Unconfined and
+     initializing the treeCaptureViewModel object.
+     */
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        treeCaptureViewModel = TreeCaptureViewModel("", userRepo, treeCapturer, sessionTracker, createFakeTreesUseCase, locationDataCapturer)
+    }
+
+    /*
+     Reset the main dispatcher after each test.
+     */
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /*
+     Test the image captured by calling setImage on treeCapturer.
+     */
+
+    @Test
+    fun `test to see image captured`() = runBlockingTest {
+        val imageFile: File
+        imageFile = File("")
+        treeCaptureViewModel.onImageCaptured(imageFile)
+        verify(treeCapturer).setImage(imageFile)
+    }
+
+    /*
+     Test if the state of GPS changes the state with the provided boolean.
+     Here it can be true or false that is why we have tests for both cases.
+
+     This will return true.
+     */
+
+    @Test
+    fun `test to see if gps state, returns true`() = runBlockingTest {
+        treeCaptureViewModel.updateBadGpsDialogState(true)
+        assertEquals(true, treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable)
+    }
+
+    /*
+     Test case explained on line 80 and 81.
+     This will return false.
+     */
+
+    @Test
+    fun `test to see if gps state, returns false`() = runBlockingTest {
+        treeCaptureViewModel.updateBadGpsDialogState(false)
+        assertEquals(false, treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable)
+    }
+
+    /*
+     Test if the update capture tutorial dialog works with the state provided boolean.
+     Here it can be true or false that is why we have tests for both cases.
+
+     This will return true.
+     */
+
+    @Test
+    fun `test to see if update capture works, returns true`() = runBlockingTest {
+        treeCaptureViewModel.updateCaptureTutorialDialog(true)
+        assertEquals(true, treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial)
+    }
+
+    /*
+     Test case explained on line 104 and 105. This will return false now.
+     */
+
+    @Test
+    fun `test to see if update capture works, returns false`() = runBlockingTest {
+        treeCaptureViewModel.updateCaptureTutorialDialog(false)
+        assertEquals(false, treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial)
+    }
+
+    /*
+     Test if createFakeTree() creates fake trees and isCreatingFakeTrees state to false.
+     This doesn't have both cases, so it is just false.
+     */
+
+    @Test
+    fun `test to create fake trees`() = runBlockingTest {
+        treeCaptureViewModel.createFakeTrees()
+        assertEquals(false, treeCaptureViewModel.state.getOrAwaitValueTest().isCreatingFakeTrees)
+    }
+}

--- a/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModelTest.kt
@@ -1,11 +1,12 @@
 package org.greenstand.android.TreeTracker.capture
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import kotlinx.coroutines.Dispatchers
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import org.greenstand.android.TreeTracker.MainCoroutineRule
 import org.greenstand.android.TreeTracker.models.SessionTracker
 import org.greenstand.android.TreeTracker.models.TreeCapturer
@@ -13,22 +14,13 @@ import org.greenstand.android.TreeTracker.models.UserRepo
 import org.greenstand.android.TreeTracker.models.location.LocationDataCapturer
 import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesUseCase
 import org.greenstand.android.TreeTracker.utils.getOrAwaitValueTest
-import org.junit.After
-import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito
-import org.mockito.Mockito.verify
 import java.io.File
-import kotlin.math.exp
 
 @ExperimentalCoroutinesApi
 class TreeCaptureViewModelTest {
-
-    /*
-     Here the Rule runs coroutines on the main thread
-     */
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -36,101 +28,64 @@ class TreeCaptureViewModelTest {
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val treeCapturer = Mockito.mock(TreeCapturer::class.java)
-    private val userRepo = Mockito.mock(UserRepo::class.java)
-    private val sessionTracker = Mockito.mock(SessionTracker::class.java)
-    private val createFakeTreesUseCase = Mockito.mock(CreateFakeTreesUseCase::class.java)
-    private val locationDataCapturer = Mockito.mock(LocationDataCapturer::class.java)
+    private val treeCapturer = mockk<TreeCapturer>()
+    private val userRepo = mockk<UserRepo>()
+    private val sessionTracker = mockk<SessionTracker>()
+    private val createFakeTreesUseCase = mockk<CreateFakeTreesUseCase>()
+    private val locationDataCapturer = mockk<LocationDataCapturer>()
 
     private lateinit var treeCaptureViewModel: TreeCaptureViewModel
 
-    /*
-     Setting the main dispatcher to Dispatcher.Unconfined and
-     initializing the treeCaptureViewModel object.
-     */
 
     @Before
     fun setUp() {
-        Dispatchers.setMain(Dispatchers.Unconfined)
-        treeCaptureViewModel = TreeCaptureViewModel("", userRepo, treeCapturer, sessionTracker, createFakeTreesUseCase, locationDataCapturer)
+        treeCaptureViewModel = TreeCaptureViewModel(
+            "",
+            userRepo,
+            treeCapturer,
+            sessionTracker,
+            createFakeTreesUseCase,
+            locationDataCapturer
+        )
     }
-
-    /*
-     Reset the main dispatcher after each test.
-     */
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    /*
-     Test the image captured by calling setImage on treeCapturer.
-     */
 
     @Test
     fun `test to see image captured`() = runBlockingTest {
-        val imageFile: File
-        imageFile = File("")
+        val imageFile = File("naphtali/android")
+        coEvery {
+            treeCapturer.setImage(imageFile)
+        } returns Unit
         treeCaptureViewModel.onImageCaptured(imageFile)
-        verify(treeCapturer).setImage(imageFile)
+        coVerify {
+            treeCapturer.setImage(imageFile)
+        }
     }
-
-    /*
-     Test if the state of GPS changes the state with the provided boolean.
-     Here it can be true or false that is why we have tests for both cases.
-
-     This will return true.
-     */
 
     @Test
     fun `test to see if gps state, returns true`() = runBlockingTest {
         treeCaptureViewModel.updateBadGpsDialogState(true)
-        assertEquals(true, treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable)
+        treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable?.let {
+            assert(
+                it
+            ) { "${treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable}" }
+        }
     }
-
-    /*
-     Test case explained on line 80 and 81.
-     This will return false.
-     */
 
     @Test
     fun `test to see if gps state, returns false`() = runBlockingTest {
         treeCaptureViewModel.updateBadGpsDialogState(false)
-        assertEquals(false, treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable)
+        assert(!treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable!!) {"${treeCaptureViewModel.state.getOrAwaitValueTest().isLocationAvailable}"}
     }
-
-    /*
-     Test if the update capture tutorial dialog works with the state provided boolean.
-     Here it can be true or false that is why we have tests for both cases.
-
-     This will return true.
-     */
 
     @Test
     fun `test to see if update capture works, returns true`() = runBlockingTest {
         treeCaptureViewModel.updateCaptureTutorialDialog(true)
-        assertEquals(true, treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial)
+        treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial?.let { assert(it) {"${treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial}"} }
     }
-
-    /*
-     Test case explained on line 104 and 105. This will return false now.
-     */
 
     @Test
     fun `test to see if update capture works, returns false`() = runBlockingTest {
         treeCaptureViewModel.updateCaptureTutorialDialog(false)
-        assertEquals(false, treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial)
-    }
-
-    /*
-     Test if createFakeTree() creates fake trees and isCreatingFakeTrees state to false.
-     This doesn't have both cases, so it is just false.
-     */
-
-    @Test
-    fun `test to create fake trees`() = runBlockingTest {
-        treeCaptureViewModel.createFakeTrees()
-        assertEquals(false, treeCaptureViewModel.state.getOrAwaitValueTest().isCreatingFakeTrees)
+        assert(!treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial!!) {"${treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial}"}
     }
 }

--- a/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModelTest.kt
@@ -1,31 +1,23 @@
 package org.greenstand.android.TreeTracker.capture
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import org.greenstand.android.TreeTracker.MainCoroutineRule
 import org.greenstand.android.TreeTracker.models.TreeCapturer
 import org.greenstand.android.TreeTracker.models.UserRepo
 import org.greenstand.android.TreeTracker.utils.getOrAwaitValueTest
-import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.verify
 
 @ExperimentalCoroutinesApi
 class TreeImageReviewViewModelTest {
 
-    /*
-     Here the Rule runs coroutines on the main thread
-     */
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -33,44 +25,27 @@ class TreeImageReviewViewModelTest {
     @get:Rule
     val mainCoroutineRule = MainCoroutineRule()
 
-    private val treeCapturer = mock(TreeCapturer::class.java)
-    private val userRepo = mock(UserRepo::class.java)
+    private val treeCapturer = mockk<TreeCapturer>()
+    private val userRepo = mockk<UserRepo>()
 
     private lateinit var treeImageReviewViewModel: TreeImageReviewViewModel
 
-    /*
-     Setting the main dispatcher to Dispatcher.Unconfined and
-     initializing the treeImageReviewViewModel object.
-     */
 
     @Before
     fun setUp() {
-        Dispatchers.setMain(Dispatchers.Unconfined)
         treeImageReviewViewModel = TreeImageReviewViewModel(treeCapturer, userRepo)
     }
 
-    /*
-     Reset the main dispatcher after each test.
-     */
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
-
-    /*
-     Test if image is approved by calling saveTree on treeCapturer.
-     */
-
     @Test
     fun `image is being approved`() = runBlockingTest {
+        coEvery {
+            treeCapturer.saveTree()
+        } returns Unit
         treeImageReviewViewModel.approveImage()
-        verify(treeCapturer).saveTree()
+        coVerify {
+            treeCapturer.saveTree()
+        }
     }
-
-    /*
-     Test if updateNote updates the state with the provided note.
-     */
 
     @Test
     fun `updateNote should update state`() = runBlockingTest {
@@ -79,62 +54,33 @@ class TreeImageReviewViewModelTest {
         assertEquals(note, treeImageReviewViewModel.state.getOrAwaitValueTest().note)
     }
 
-    /*
-     Test if updateReviewTutorialDialog updates the state with the provided boolean.
-     Here it can be true or false that is why we have tests for both cases.
-
-    This will return tru
-     */
-
     @Test
     fun `updateNote review tutorial dialog, returns true`() = runBlockingTest {
-        val state = true
         treeImageReviewViewModel.updateReviewTutorialDialog(true)
-        assertEquals(state, treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial)
+        treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial?.let { assert(it) { "${treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial}" } }
     }
-
-    /*
-     Test case explained on line 77 and 79. This will return false now.
-     */
 
     @Test
     fun `updateNote review tutorial dialog, returns false`() = runBlockingTest {
-        val falseState = false
         treeImageReviewViewModel.updateReviewTutorialDialog(false)
-        assertEquals(falseState, treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial)
+        assert(!treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial!!) { "${treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial}" }
     }
-
-    /*
-     Test if addNote updates the isDialogOpen state to false.
-     This doesn't have both cases, so it is just false.
-     */
 
     @Test
-    fun `addNote setsNote And ClosesDialog`() = runBlockingTest {
+    fun `addNote setsNote And ClosesDialog, returns false`() = runBlockingTest {
         treeImageReviewViewModel.addNote()
-        assertEquals(false, treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen)
+        assert(!treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen) { "${treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen}" }
     }
-
-    /*
-     Test if setDialogState updates the isDialogOpen state with the provided boolean.
-     Here it can be true or false that is why we have tests for both cases.
-     */
 
     @Test
     fun `set Dialog state, check if dialog is open, returns true`() = runBlockingTest {
-        val dialogState = true
-        treeImageReviewViewModel.setDialogState(dialogState)
-        assertEquals(dialogState, treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen)
+        treeImageReviewViewModel.setDialogState(true)
+        assert(treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen) { "${treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen}" }
     }
-
-    /*
-     Test case explained on line 111 and 112.
-     */
 
     @Test
     fun `set Dialog state, check if dialog is closed, returns false`() = runBlockingTest {
-        val dialogState = false
-        treeImageReviewViewModel.setDialogState(dialogState)
-        assertEquals(dialogState, treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen)
+        treeImageReviewViewModel.setDialogState(false)
+        assert(!treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen) { "${treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen}" }
     }
 }

--- a/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModelTest.kt
@@ -1,0 +1,140 @@
+package org.greenstand.android.TreeTracker.capture
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.greenstand.android.TreeTracker.MainCoroutineRule
+import org.greenstand.android.TreeTracker.models.TreeCapturer
+import org.greenstand.android.TreeTracker.models.UserRepo
+import org.greenstand.android.TreeTracker.utils.getOrAwaitValueTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+@ExperimentalCoroutinesApi
+class TreeImageReviewViewModelTest {
+
+    /*
+     Here the Rule runs coroutines on the main thread
+     */
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private val treeCapturer = mock(TreeCapturer::class.java)
+    private val userRepo = mock(UserRepo::class.java)
+
+    private lateinit var treeImageReviewViewModel: TreeImageReviewViewModel
+
+    /*
+     Setting the main dispatcher to Dispatcher.Unconfined and
+     initializing the treeImageReviewViewModel object.
+     */
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        treeImageReviewViewModel = TreeImageReviewViewModel(treeCapturer, userRepo)
+    }
+
+    /*
+     Reset the main dispatcher after each test.
+     */
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /*
+     Test if image is approved by calling saveTree on treeCapturer.
+     */
+
+    @Test
+    fun `image is being approved`() = runBlockingTest {
+        treeImageReviewViewModel.approveImage()
+        verify(treeCapturer).saveTree()
+    }
+
+    /*
+     Test if updateNote updates the state with the provided note.
+     */
+
+    @Test
+    fun `updateNote should update state`() = runBlockingTest {
+        val note = "note"
+        treeImageReviewViewModel.updateNote(note)
+        assertEquals(note, treeImageReviewViewModel.state.getOrAwaitValueTest().note)
+    }
+
+    /*
+     Test if updateReviewTutorialDialog updates the state with the provided boolean.
+     Here it can be true or false that is why we have tests for both cases.
+
+    This will return tru
+     */
+
+    @Test
+    fun `updateNote review tutorial dialog, returns true`() = runBlockingTest {
+        val state = true
+        treeImageReviewViewModel.updateReviewTutorialDialog(true)
+        assertEquals(state, treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial)
+    }
+
+    /*
+     Test case explained on line 77 and 79. This will return false now.
+     */
+
+    @Test
+    fun `updateNote review tutorial dialog, returns false`() = runBlockingTest {
+        val falseState = false
+        treeImageReviewViewModel.updateReviewTutorialDialog(false)
+        assertEquals(falseState, treeImageReviewViewModel.state.getOrAwaitValueTest().showReviewTutorial)
+    }
+
+    /*
+     Test if addNote updates the isDialogOpen state to false.
+     This doesn't have both cases, so it is just false.
+     */
+
+    @Test
+    fun `addNote setsNote And ClosesDialog`() = runBlockingTest {
+        treeImageReviewViewModel.addNote()
+        assertEquals(false, treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen)
+    }
+
+    /*
+     Test if setDialogState updates the isDialogOpen state with the provided boolean.
+     Here it can be true or false that is why we have tests for both cases.
+     */
+
+    @Test
+    fun `set Dialog state, check if dialog is open, returns true`() = runBlockingTest {
+        val dialogState = true
+        treeImageReviewViewModel.setDialogState(dialogState)
+        assertEquals(dialogState, treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen)
+    }
+
+    /*
+     Test case explained on line 111 and 112.
+     */
+
+    @Test
+    fun `set Dialog state, check if dialog is closed, returns false`() = runBlockingTest {
+        val dialogState = false
+        treeImageReviewViewModel.setDialogState(dialogState)
+        assertEquals(dialogState, treeImageReviewViewModel.state.getOrAwaitValueTest().isDialogOpen)
+    }
+}

--- a/app/src/test/java/org/greenstand/android/TreeTracker/orgpicker/OrgPickerViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/orgpicker/OrgPickerViewModelTest.kt
@@ -1,0 +1,68 @@
+package org.greenstand.android.TreeTracker.orgpicker
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.greenstand.android.TreeTracker.MainCoroutineRule
+import org.greenstand.android.TreeTracker.models.organization.Destination
+import org.greenstand.android.TreeTracker.models.organization.Org
+import org.greenstand.android.TreeTracker.models.organization.OrgRepo
+import org.greenstand.android.TreeTracker.utils.getOrAwaitValueTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+
+@ExperimentalCoroutinesApi
+class OrgPickerViewModelTest {
+    /*
+     Here the Rule runs coroutines on the main thread
+     */
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainCoroutineRule = MainCoroutineRule()
+
+    private val orgRepo = Mockito.mock(OrgRepo::class.java)
+
+    private lateinit var orgPickerViewModel: OrgPickerViewModel
+
+    /*
+     Setting the main dispatcher to Dispatcher.Unconfined and
+     initializing the treeImageReviewViewModel object.
+     */
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        orgPickerViewModel = OrgPickerViewModel(orgRepo)
+    }
+
+    /*
+     Reset the main dispatcher after each test.
+     */
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /*
+     Test if setOrg sets to the current org to null.
+     */
+
+    @Test
+    fun `test for set org`() = runBlockingTest {
+        val org = null
+        org?.let { orgPickerViewModel.setOrg(it) }
+        val actualState = orgPickerViewModel.state.getOrAwaitValueTest()
+        assertEquals(org, actualState.currentOrg)
+    }
+}


### PR DESCRIPTION
Added unit tests for the following view models:
**OrgPickerViewModel.kt**
**TreeCaptureViewModel.kt**
**TreeImageReviewViewModel.kt**