### PR TITLE
end convergence only when exiting session

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
@@ -65,11 +65,6 @@ class TreeCaptureViewModel(
         _state.value = _state.value?.copy(showCaptureTutorial = state)
     }
 
-    suspend fun endSession() {
-        locationDataCapturer.stopGpsUpdates()
-        sessionTracker.endSession()
-    }
-
     suspend fun isFirstTrack(): Boolean = userRepo.getPowerUser()!!.numberOfTrees < 1
 
     suspend fun createFakeTrees() {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewViewModel.kt
@@ -39,7 +39,7 @@ class TreeImageReviewViewModel(
         _state.value = _state.value?.copy(showReviewTutorial = state)
     }
 
-    fun addNote(){
+    fun addNote() {
         viewModelScope.launch {
             treeCapturer.setNote(_state.value!!.note)
             _state.value = _state.value?.copy(isDialogOpen = false)
@@ -48,7 +48,7 @@ class TreeImageReviewViewModel(
 
     suspend fun isFirstTrack(): Boolean = userRepo.getPowerUser()!!.numberOfTrees < 1
 
-    fun setDialogState(state: Boolean){
+    fun setDialogState(state: Boolean) {
         _state.value = _state.value?.copy(isDialogOpen = state)
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeCapturer.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeCapturer.kt
@@ -26,10 +26,8 @@ class TreeCapturer(
         newTreeUuid = locationDataCapturer.generatedTreeUuid
         return if (locationDataCapturer.isLocationCoordinateAvailable()) {
             convergence = locationDataCapturer.convergence()
-            locationDataCapturer.turnOffTreeCaptureMode()
             true
         } else {
-            locationDataCapturer.turnOffTreeCaptureMode()
             false
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturer.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturer.kt
@@ -47,8 +47,8 @@ class LocationDataCapturer(
         }
     }
 
-    private val locationObserver: Observer<Location?> = Observer { location ->
-        location?.apply {
+    private val locationObserver: Observer<Location?> = Observer { l ->
+        l?.let { location ->
             val locationDataConfig = configuration.locationDataConfig
             val convergenceDataSize = locationDataConfig.convergenceDataSize
             if (isInTreeCaptureMode()) {
@@ -104,9 +104,9 @@ class LocationDataCapturer(
                     val locationData =
                         LocationData(
                             currentSessionId,
-                            latitude,
-                            longitude,
-                            accuracy,
+                            location.latitude,
+                            location.longitude,
+                            location.accuracy,
                             generatedTreeUuid?.toString(),
                             convergenceStatus,
                             timeProvider.currentTime().toString(),

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationUpdateManager.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationUpdateManager.kt
@@ -93,10 +93,6 @@ class LocationUpdateManager(
         }
     }
 
-    fun isLocationEnabled(): Boolean {
-        return locationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
-    }
-
     private fun hasLocationPermissions(): Boolean {
         val fineLocationPermission = ContextCompat.checkSelfPermission(
             context,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/navigation/CaptureFlowNavigationController.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/navigation/CaptureFlowNavigationController.kt
@@ -78,6 +78,7 @@ class CaptureFlowNavigationController(
             stepCounter.disable()
             withContext(Dispatchers.Main) {
                 locationDataCapturer.stopGpsUpdates()
+                locationDataCapturer.turnOffTreeCaptureMode()
             }
         }
     }

--- a/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModelTest.kt
@@ -5,7 +5,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.greenstand.android.TreeTracker.MainCoroutineRule
@@ -124,14 +123,6 @@ class TreeCaptureViewModelTest {
     fun `WHEN updateCaptureTutorialDialog true THEN showCaptureTutorial state true`() = runBlocking {
         treeCaptureViewModel.updateCaptureTutorialDialog(true)
         assertTrue(treeCaptureViewModel.state.getOrAwaitValueTest().showCaptureTutorial ?: false)
-    }
-
-    @Test
-    fun `WHEN end session THEN stopGpsUpdates and endSession functions were called one time`() = runBlocking {
-        treeCaptureViewModel.endSession()
-
-        verify(exactly = 1) { locationDataCapturer.stopGpsUpdates() }
-        coVerify(exactly = 1) { sessionTracker.endSession() }
     }
 
     @Test


### PR DESCRIPTION
Convergence was started and stopped per tree. This changes it to start for the first tree, and only stop after the capture session is over.