### PR TITLE
Update location upload status in chunks

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
@@ -14,7 +14,6 @@ import org.greenstand.android.TreeTracker.database.entity.OrganizationEntity
 import org.greenstand.android.TreeTracker.database.entity.SessionEntity
 import org.greenstand.android.TreeTracker.database.entity.TreeEntity
 import org.greenstand.android.TreeTracker.database.entity.UserEntity
-import org.greenstand.android.TreeTracker.database.legacy.entity.LocationDataEntity
 import org.greenstand.android.TreeTracker.database.legacy.entity.PlanterCheckInEntity
 import org.greenstand.android.TreeTracker.database.legacy.entity.PlanterInfoEntity
 import org.greenstand.android.TreeTracker.database.legacy.entity.TreeAttributeEntity
@@ -219,9 +218,6 @@ interface TreeTrackerDAO {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertLocationData(locationEntity: LocationEntity): Long
-
-    @Query("SELECT * FROM location_data WHERE uploaded = 0")
-    suspend fun getTreeLocationData(): List<LocationDataEntity>
 
     @Query("SELECT * FROM location WHERE uploaded = 0")
     suspend fun getLocationData(): List<LocationEntity>

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/SyncDataUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/SyncDataUseCase.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.models.DeviceConfigUploader
-import org.greenstand.android.TreeTracker.models.FeatureFlags
 import org.greenstand.android.TreeTracker.models.PlanterUploader
 import org.greenstand.android.TreeTracker.models.SessionUploader
 import org.greenstand.android.TreeTracker.models.TreeUploader
@@ -62,7 +61,7 @@ class SyncDataUseCase(
 
             }
         } catch(e: Exception) {
-            Timber.e("Error occured during syncing data. ${e.localizedMessage}")
+            Timber.e("Error occurred during syncing data. ${e.localizedMessage}")
             return false
         }
         return true

--- a/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/usecases/UploadLocationDataUseCase.kt
@@ -56,10 +56,15 @@ class UploadLocationDataUseCase(
                     "${dataBundle.md5()}_tracks"
                 )
 
-                dao.updateLocationDataUploadStatus(locationEntities.map { it.id }, true)
+                locationEntities
+                    .map { it.id }
+                    .chunked(60)
+                    .onEach { ids ->
+                        dao.updateLocationDataUploadStatus(ids, true)
+                    }
                 dao.purgeUploadedLocations()
 
-                Timber.d("Completed uploading ${locationEntities.size} V2 GPS locations")
+                Timber.tag("Location Upload").d("Completed uploading ${locationEntities.size} V2 GPS locations")
             }
         } catch (ace: AmazonClientException) {
             Timber.e(


### PR DESCRIPTION
If there are many locations, it would become to big to pass as a list of IDs. In my testing with 60k location points, there was an error when trying to update them all. By updating 60 at a time (1 minutes worth) there is no more issue.