### PR TITLE
chore(ci): Update workflow to use JDK 17

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,11 +11,12 @@ jobs:
     name: test and assemble
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
+          distribution: 'temurin'
       - name: Generate dummy property file
         run: |
           echo "#Treetracker API Keys

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -232,7 +232,7 @@ dependencies {
     implementation 'androidx.room:room-ktx:2.4.0-beta01'
     kapt "androidx.room:room-compiler:2.4.0-beta01"
 
-    devImplementation 'com.amitshekhar.android:debug-db:1.0.6'
+    devImplementation 'com.github.amitshekhariitbhu.Android-Debug-Database:debug-db:v1.0.6'
 
     api "com.squareup.retrofit2:converter-gson:${retrofit2Version}"
     implementation "com.squareup.retrofit2:retrofit:${retrofit2Version}"


### PR DESCRIPTION
This PR updates the CI workflow to use JDK 17, which is required for the latest Android Gradle plugin.

This change is necessary to unblock the PR for updating the target SDK version to 34 (#1112).

The workflow file has been updated to use `actions/setup-java@v3` with `java-version: '17'`.

This update ensures that the CI environment uses the correct JDK version for building the project.

Thank you for opening a Pull Request!

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests are added/updated (if necessary)
- [ ] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1113 🦕
Fixes #1115 
