### PR TITLE
feat: complete logout and re-login feature

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/TreeTrackerDAO.kt
@@ -74,6 +74,10 @@ interface TreeTrackerDAO {
     @Query("SELECT * FROM user WHERE power_user = 1")
     suspend fun getPowerUser(): UserEntity?
 
+    @Query("UPDATE user SET power_user = :isPowerUser WHERE _id = :userId")
+    suspend fun updatePowerUserStatus(userId: Long, isPowerUser: Boolean)
+
+
     @Update
     suspend fun updatePlanterInfo(planterInfoEntity: PlanterInfoEntity)
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/user/UserRepo.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/user/UserRepo.kt
@@ -63,6 +63,11 @@ class UserRepo(
         val userEntity = dao.getPowerUser() ?: return null
         return createUser(userEntity)
     }
+    suspend fun setPowerUserStatus(userId: Long, isPowerUser: Boolean) {
+        if (!isPowerUser || getPowerUser() == null) {
+            dao.updatePowerUserStatus(userId, isPowerUser)
+        }
+    }
 
     suspend fun createUser(
         firstName: String,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/settings/SettingsScreen.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 import org.greenstand.android.TreeTracker.root.LocalNavHostController
 import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.signup.Credential
@@ -37,11 +38,16 @@ import org.greenstand.android.TreeTracker.userselect.UserSelectState
 import org.greenstand.android.TreeTracker.userselect.UserSelectViewModel
 import org.greenstand.android.TreeTracker.userselect.UserSelectViewModelFactory
 import org.greenstand.android.TreeTracker.view.ActionBar
+import org.greenstand.android.TreeTracker.view.AppButtonColors
 import org.greenstand.android.TreeTracker.view.AppColors
+import org.greenstand.android.TreeTracker.view.AppColors.Green
+import org.greenstand.android.TreeTracker.view.AppColors.Red
 import org.greenstand.android.TreeTracker.view.ArrowButton
 import org.greenstand.android.TreeTracker.view.LanguageButton
 import org.greenstand.android.TreeTracker.view.dialogs.PrivacyPolicyDialog
 import org.greenstand.android.TreeTracker.view.TopBarTitle
+import org.greenstand.android.TreeTracker.view.UserButton
+import org.greenstand.android.TreeTracker.view.dialogs.CustomDialog
 
 @Composable
 fun SettingsScreen() {
@@ -113,7 +119,9 @@ fun SettingsScreen() {
                     iconResId = R.drawable.logout, // Replace with your logout icon
                     titleResId = R.string.logout_title,
                     descriptionResId = R.string.logout_description,
-                    onClick = { /* Handle logout click */ }
+                    onClick = {
+                        viewModel.updateLogoutDialogVisibility(true)
+                    }
                 )
                 Divider(color = Color.White)
 
@@ -126,6 +134,33 @@ fun SettingsScreen() {
             }
             if (state.showPrivacyPolicyDialog == true) {
                 PrivacyPolicyDialog(settingsViewModel = viewModel)
+            }
+            if(state.showLogoutDialog == true){
+                CustomDialog(
+                    title = stringResource(R.string.logout_dialog_title),
+                    textContent = stringResource(R.string.logout_dialog_message),
+                    onPositiveClick = {
+                        viewModel.logout()
+                        navController.navigate(NavRoute.SignupFlow.route)
+                    },
+                    onNegativeClick = {
+                        viewModel.updateLogoutDialogVisibility(false)
+                    },
+                    content = {
+                        state.powerUser?.let { user ->
+                            UserButton(
+                                user = user,
+                                isSelected = false,
+                                buttonColors = AppButtonColors.Default,
+                                selectedColor = Red,
+                                onClick = {
+                                }
+                            )
+                        }
+
+                    }
+
+                )
             }
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/settings/SettingsViewmodel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/settings/SettingsViewmodel.kt
@@ -7,9 +7,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.models.UserRepo
+import org.greenstand.android.TreeTracker.models.user.User
 
 data class SettingsState(
     val showPrivacyPolicyDialog: Boolean? = null,
+    val showLogoutDialog: Boolean? = null,
+    val showDeleteAccountDialog: Boolean? = null,
+    val powerUser: User? = null
 )
 
 class SettingsViewModel(
@@ -20,13 +24,32 @@ class SettingsViewModel(
     val state: Flow<SettingsState> = _state
 
     init {
-
+        viewModelScope.launch {
+            _state.value = _state.value.copy(
+                powerUser = userRepo.getPowerUser()
+            )
+        }
     }
 
     fun setPrivacyDialogVisibility(show: Boolean) {
         viewModelScope.launch {
             _state.value = _state.value.copy(
                 showPrivacyPolicyDialog = show
+            )
+        }
+    }
+    fun logout(){
+        viewModelScope.launch {
+            _state.value.powerUser?.let {
+                userRepo.setPowerUserStatus(it.id, false)
+            }
+            updateLogoutDialogVisibility(false)
+        }
+    }
+    fun updateLogoutDialogVisibility(show: Boolean) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(
+                showLogoutDialog = show
             )
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.greenstand.android.TreeTracker.R
 import org.greenstand.android.TreeTracker.models.NavRoute
+import org.greenstand.android.TreeTracker.models.setupflow.CaptureSetupScopeManager
 import org.greenstand.android.TreeTracker.root.LocalNavHostController
 import org.greenstand.android.TreeTracker.settings.SettingsViewModel
 import org.greenstand.android.TreeTracker.theme.CustomTheme
@@ -331,9 +332,16 @@ fun ExistingUserDialog(
                     buttonColors = AppButtonColors.Default,
                     selectedColor = Green,
                     onClick = {
-                        navController.navigate(NavRoute.WalletSelect.create()) {
-                            popUpTo(NavRoute.SignupFlow.route) { inclusive = true }
-                            launchSingleTop = true
+
+                        if(state.isTherePowerUser == false){
+                            viewModel.setExistingUserAsPowerUser(user.id)
+                            navController.navigate(NavRoute.Dashboard.route) {
+                                popUpTo(NavRoute.Language.route) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        } else {
+                            CaptureSetupScopeManager.getData().user = user
+                            CaptureSetupScopeManager.nav.navFromNewUserCreation(navController)
                         }
                     }
                 )

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/SignupViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/SignupViewModel.kt
@@ -40,6 +40,7 @@ data class SignUpState(
     val credential: Credential = Credential.Phone(),
     val autofocusTextEnabled: Boolean = false,
     val isInternetAvailable: Boolean = false,
+    val isTherePowerUser: Boolean? = null,
     val showSelfieTutorial: Boolean? = null,
     val showPrivacyDialog: Boolean? = true,
 )
@@ -84,7 +85,7 @@ class SignupViewModel(
     init {
         viewModelScope.launch(Dispatchers.Main) {
             val result = checkForInternetUseCase.execute(Unit)
-            _state.value = _state.value?.copy(isInternetAvailable = result, showSelfieTutorial = isInitialSetupRequired())
+            _state.value = _state.value?.copy(isInternetAvailable = result, showSelfieTutorial = isInitialSetupRequired(), isTherePowerUser = !isInitialSetupRequired())
         }
     }
 
@@ -94,6 +95,12 @@ class SignupViewModel(
 
     fun updateLastName(lastName: String?) {
         _state.value = _state.value?.copy(lastName = lastName)
+    }
+
+    fun setExistingUserAsPowerUser(id: Long){
+        viewModelScope.launch {
+                userRepo.setPowerUserStatus(id, true)
+        }
     }
 
     fun updateEmail(email: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@ Privacy Policy
     <string name="logout_description">Log out from your account.</string>
     <string name="delete_account_title">Delete Account</string>
     <string name="delete_account_description">Initiate the process to delete your account completely.</string>
+    <string name="logout_dialog_title">Are you sure you want to logout?</string>
+    <string name="delete_dialog_description">If you logout you will have to re-enter email or phone number again to access all trees captured and your account</string>
     <string name="delete_account_dialog_message">Are you sure you want your account deleted?  \n This is irreversible and you would loose all your data.</string>
     <string name="logout_dialog_message"> Are you sure you want to log out from your account?</string>
 


### PR DESCRIPTION
Introducing a logout feature which allows planter to logout the power user(basically sets power user to false) and takes them back to sign up without deleting any data, when anyone login again all data are still there and can be uploaded. Also new users and existing users can login after power user has logged out and will become new power user.
