### PR TITLE
Fix profile fields width by adding modifier support to BorderedTextField

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ def loadExtraProperties(String fileName) {
     }
 }
 
-//loadExtraProperties("treetracker.keys.properties")
+loadExtraProperties("treetracker.keys.properties")
 
 android {
     compileSdkVersion 34

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ def loadExtraProperties(String fileName) {
     }
 }
 
-loadExtraProperties("treetracker.keys.properties")
+//loadExtraProperties("treetracker.keys.properties")
 
 android {
     compileSdkVersion 34

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/BorderedTextField.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/BorderedTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -62,6 +63,7 @@ fun BorderedTextField(
         TextField(
             modifier = Modifier
                 .padding(8.dp)
+                .fillMaxSize()
                 .focusRequester(focusRequester)
                 .onFocusChanged(onFocusChanged),
             value = value,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/BorderedTextField.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/BorderedTextField.kt
@@ -40,26 +40,24 @@ import org.greenstand.android.TreeTracker.theme.CustomTheme
 
 @Composable
 fun BorderedTextField(
+    modifier: Modifier = Modifier,
     padding: PaddingValues = PaddingValues(0.dp),
     value: String,
-
     onValueChange: (String) -> Unit,
     placeholder: @Composable (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions(),
     onFocusChanged: ((FocusState) -> Unit) = {},
     focusRequester: FocusRequester = FocusRequester.Default,
-    autofocusEnabled: Boolean = false
+    autofocusEnabled: Boolean = false,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .padding(padding)
             .border(
                 BorderStroke(0.5.dp, SolidColor(Color.White)),
                 RoundedCornerShape(16.dp),
             )
-            .padding(padding)
-
     ) {
         TextField(
             modifier = Modifier

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/ProfileField.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/ProfileField.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,15 +15,18 @@ fun ProfileField(
     label: String,
     value: String,
     editable: Boolean,
-    onValueChange: (String) -> Unit
+    onValueChange: (String) -> Unit,
 ) {
-    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp)) {
+    Column(modifier = Modifier
+        .fillMaxWidth()
+        .padding(vertical = 6.dp)) {
         Text(label, style = CustomTheme.typography.medium, color = CustomTheme.textColors.lightText)
         if (editable) {
             BorderedTextField(
-                padding = PaddingValues(top = 8.dp, ),
+                padding = PaddingValues(top = 8.dp),
                 value = value,
                 onValueChange = onValueChange,
+                modifier = Modifier.fillMaxWidth()
             )
         } else {
             Text(value, style = CustomTheme.typography.large)


### PR DESCRIPTION
# Fix profile fields width by adding modifier support to BorderedTextField

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests are added/updated (if necessary)
- [x] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
- [x] Appropriate docs were updated (if necessary)

## Description
This PR fixes an issue where the profile fields in the ProfileScreen weren't filling the maximum width of the screen, leaving unused space on the right side. The root cause was that the BorderedTextField component didn't accept a modifier parameter, preventing it from receiving layout directives from its parent components.

## Changes
- Added a modifier parameter to the BorderedTextField component
- Applied the modifier to the Box wrapper in BorderedTextField
- Updated ProfileField to pass Modifier.fillMaxWidth() to BorderedTextField
- Removed redundant padding application in BorderedTextField for cleaner code

## Visual Changes
Before: Profile fields didn't utilize the full width of the screen, leaving empty space on the right
![image](https://github.com/user-attachments/assets/de06a8a9-7c55-4770-a420-c3eb0b7dd0da)

After: Profile fields now properly extend to fill the entire width of the screen
![image](https://github.com/user-attachments/assets/44937a1b-ef5d-45b8-8ddb-e374ab5ff2a8)

Fixes #1138 🦕
