### PR TITLE
Add Swahili translations for all new strings in 2.2 milestone (#1149)

### DIFF
--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -168,6 +168,42 @@
     <string name="no_gps_device_header">Hakuna GPS kwenye kifaa hiki</string>
     <string name="no_gps_device_content">Kifaa hiki hakina uwezo wa kuwa na GPS. Tafadhali tumia kifaa chenye GPS ili kuendelea.</string>
     <string name="tree_capture_review_text">bonyeza kitufe ili kuongeza taarifa</string>
+
+
+    <string name="settings">Mipangilio</string>
+    <string name="profile_title">Tazama / Hariri Wasifu</string>
+    <string name="cancel_edit">Ghairi Hariri</string>
+    <string name="edit_profile">Hariri Wasifu</string>
+    <string name="save_changes">Hifadhi Mabadiliko</string>
+    <string name="loading_user_profile">Inapakia wasifu wa mtumiaji.....</string>
+    <string name="profile_description">Bofya hapa kutazama au kuhariri maelezo ya wasifu wako</string>
+    <string name="privacy_title">Tazama sera ya faragha.</string>
+    <string name="privacy_description">Bofya hapa kutazama sera ya faragha ya Greenstand kuhusu taarifa zako.</string>
+    <string name="logout_title">Toka kwenye akaunti</string>
+    <string name="logout_description">Toka kwenye akaunti yako</string>
+    <string name="delete_account_title">Futa akaunti</string>
+    <string name="account_deleted">Akaunti imefutwa</string>
+    <string name="account_deleted_message">Taarifa zako zote zimefutwa</string>
+    <string name="delete_account_description">Anza mchakato wa kufuta akaunti yako kabisa.</string>
+    <string name="logout_dialog_title">Una uhakika unataka kutoka kwenye akaunto yako?</string>
+    <string name="delete_account_dialog_title">Una uhakika unataka kufuta akauti hii?</string>
+    <string name="delete_account_dialog_message">Una uhakika unataka kufuta akaunti yako? Ukifanya hivi, hutaweza kurudisha tena na data zako zote zitapotea. Hakikisha umeunganishwa na intaneti ili kukamilisha hatua hii.</string>
+    <string name="logout_dialog_message">Una uhakika unataka kutoka kwenya akaunti yako?</string>
+    <string name="announcement">Tangazo</string>
+    <string name="click_to_write_message">Bofya kuandika ujumbe.</string>
+    <string name="no_internet_header">Hamna intaneti.</string>
+    <string name="no_internet_content">Tafadhali ungana na WiFi au washa data ya simu ili kufungua kiungo hiki.</string>
+    <string name="tracking_progress_header">Ufuatiliaji unaendelea.</string>
+    <string name="tracking_progress_message">Usisongeshe simu mpaka ufuatiliaji ukamilike.</string>
+    <string name="privacy_policy">Sera ya faragha</string>
+    <string name="select_tree_height_colour">Chagua rangi ya urefu wa mti.</string>
+    <string name="select_organization">Chagua shirika.</string>
+    <string name="no_messages_yet">Bado hakuna ujumbe.</string>
+    <string name="survey_completed">Utafuti umekamilika.</string>
+    <string name="upload_trees_soon_title">Pakia miti hivi karibuni.</string>
+    <string name="upload_trees_text_content">Una zaidi ya miti 2000, tafadhali pakia haraka iwezekanavyo.</string>
+    <string name="add_note_to_session">Ongeza kumbukumbu kwenye kikao.</string>
+
 </resources>
 
 


### PR DESCRIPTION
- Swahili translations for new English strings added in 2.2, using approved translations from the spreadsheet.

Fixes #1149 
