### PR TITLE
Fix selfie image being saved as mirrored (#943)

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/ImageUtils.kt
@@ -445,35 +445,43 @@ object ImageUtils {
         } else {
             ExifInterface.ORIENTATION_NORMAL
         }
-        val rotationAngle = when (orientation) {
-            ExifInterface.ORIENTATION_ROTATE_90 -> 90
-            ExifInterface.ORIENTATION_ROTATE_180 -> 180
-            ExifInterface.ORIENTATION_ROTATE_270 -> 270
-            ExifInterface.ORIENTATION_TRANSVERSE -> 270
-            else -> 0
+
+        val noScale = 1f
+        val mirrorScale = -1f
+        val rotate90 = 90f
+        val rotate180 = 180f
+        val rotate270 = 270f
+
+        val matrix = Matrix()
+        when (orientation) {
+            ExifInterface.ORIENTATION_NORMAL -> return
+            ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.preScale(mirrorScale, noScale)
+            ExifInterface.ORIENTATION_ROTATE_180 -> matrix.setRotate(rotate180)
+            ExifInterface.ORIENTATION_FLIP_VERTICAL -> {
+                matrix.setRotate(rotate180)
+                matrix.postScale(mirrorScale, noScale)
+            }
+            ExifInterface.ORIENTATION_TRANSPOSE -> {
+                matrix.setRotate(rotate90)
+                matrix.postScale(mirrorScale, noScale)
+            }
+            ExifInterface.ORIENTATION_ROTATE_90 -> matrix.setRotate(rotate90)
+            ExifInterface.ORIENTATION_TRANSVERSE -> {
+                matrix.setRotate(rotate270)
+                matrix.postScale(mirrorScale, noScale)
+            }
+            ExifInterface.ORIENTATION_ROTATE_270 -> matrix.setRotate(rotate270)
+            else -> return
         }
 
-        val matrix = Matrix().apply {
-            setRotate(
-                rotationAngle.toFloat(),
-                bmOptions.outWidth.toFloat() / 2,
-                bmOptions.outHeight.toFloat() / 2
-            )
-        }
-
-        val rotatedBitmap = Bitmap.createBitmap(
-            BitmapFactory.decodeFile(photoPath),
-            0,
-            0,
-            bmOptions.outWidth,
-            bmOptions.outHeight,
-            matrix,
-            true
+        val sourceBitmap = BitmapFactory.decodeFile(photoPath) ?: return
+        val transformedBitmap = Bitmap.createBitmap(
+            sourceBitmap, 0, 0, sourceBitmap.width, sourceBitmap.height, matrix, true
         )
 
         val compressionQuality = 70
         val byteArrayBitmapStream = ByteArrayOutputStream()
-        rotatedBitmap.compress(
+        transformedBitmap.compress(
             Bitmap.CompressFormat.JPEG, compressionQuality,
             byteArrayBitmapStream
         )


### PR DESCRIPTION
The root cause was in orientImage() inside ImageUtils: it only handled
   EXIF rotation values (90/180/270deg) and silently ignored flip orientations.
   CameraX encodes the front camera correction as EXIF ORIENTATION_FLIP_HORIZONTAL,
   which was never applied to the pixel data, leaving the image mirrored.

   Changes:
   - Fix orientImage() to handle all 8 EXIF orientation cases, including FLIP_HORIZONTAL, FLIP_VERTICAL, TRANSPOSE and TRANSVERSE (previously TRANSVERSE was also missing its flip component)
   - Replace magic number literals with named variables (noScale, mirrorScale, rotate90, rotate180, rotate270) for readability
   - Use sourceBitmap.width/height instead of bmOptions dimensions for correctness when creating the transformed bitmap

Note: ./codeAnalysis.sh fails with a pre-existing JDK/ktlint incompatibility (ktlint 0.43.2 is not compatible with JDK 16+). 
This is not related to this PR.

Fixes #943 🦕
