### PR TITLE
Portuguese translations for 2.2 (#1148)

### DIFF
--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -78,7 +78,7 @@
     <string name="lon_std_dev_threshold" translatable="false">Limite do desvio padrão para a Longitude</string>
     <string name="lat_std_dev_threshold" translatable="false">Limite do desvio padrão para a Latitude</string>
     <string name="add_note_to_tree">Adicionar nota sobre a árvore</string>
-    <string name="note">NOTAS</string>
+    <string name="note">NOTA</string>
 
     <!--Strings for the permission management and rationale-->
     <string name="accept_camera_permission_header">Permitir acesso a câmera</string>
@@ -105,7 +105,7 @@
     <string name="capture_tutorial">Clique no botão para salvar esta árvore.</string>
     <string name="phone_validation_error">Número de telefone inválido. O número deve ter no mínimo 7 digitos e no máximo e 15 digitos</string>
     <string name="email_validation_error">E-mail inválido. O endereço de e-mail deve ter o símbolo @</string>
-    <string name="tree_capture_review_text">Clique no botão para adicionar notas.</string>
+    <string name="tree_capture_review_text">Clique no botão para adicionar nota.</string>
     <string name="survey">Pesquisa</string>
     <string name="message">Mensagem</string>
     <string name="policy_text_blob">


### PR DESCRIPTION
Adds and aligns Portuguese translations for the 2.2 release.

- Add missing Portuguese strings for the Settings screen (titles, descriptions, dialogs)
- Add Portuguese translations for map labels, GPS/device messages, and upload warnings
- Add Portuguese name validation error messages and session-note text
- Ensure `values-pt/strings.xml` has full key parity with the base `values/strings.xml`

Thank you for opening a Pull Request!

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests are added/updated (if necessary)
- [ ] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1148 🦕