### PR TITLE
Upgrade targetSdk 33 to 35 with full build toolchain migration DO NOT MERGE

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,10 @@ apply plugin: "androidx.navigation.safeargs"
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 
+kapt {
+    correctErrorTypes = true
+}
+
 def loadExtraProperties(String fileName) {
     def props = new Properties()
     props.load(new FileInputStream(fileName))
@@ -17,13 +21,13 @@ def loadExtraProperties(String fileName) {
 loadExtraProperties("treetracker.keys.properties")
 
 android {
-    compileSdkVersion 33
-    buildToolsVersion '30.0.3'
+    compileSdk 35
+    namespace 'org.greenstand.android.TreeTracker'
 
     defaultConfig {
         applicationId "org.greenstand.android.TreeTracker"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdk 21
+        targetSdk 35
         versionCode 195
         versionName "2.1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -55,10 +59,11 @@ android {
     buildFeatures {
         compose true
         viewBinding true
+        buildConfig true
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     composeOptions {
@@ -66,16 +71,14 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
 
         coreLibraryDesugaringEnabled = true
     }
 
-    lintOptions {
+    lint {
         checkReleaseBuilds false
-        // Or, if you prefer, you can continue to check for errors in release builds,
-        // but continue the build even when errors are found:
         abortOnError false
     }
 
@@ -156,24 +159,16 @@ android {
 
     useLibrary 'org.apache.http.legacy'
 
-    packagingOptions {
-        exclude 'META-INF/DEPENDENCIES'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/LICENSE.txt'
-        exclude 'META-INF/license.txt'
-        exclude 'META-INF/NOTICE'
-        exclude 'META-INF/NOTICE.txt'
-        exclude 'META-INF/notice.txt'
-        exclude 'META-INF/ASL2.0'
-        exclude 'META-INF/io.netty.versions.properties'
-        exclude 'META-INF/INDEX.LIST'
-
+    packaging {
+        resources {
+            excludes += ['META-INF/DEPENDENCIES', 'META-INF/LICENSE', 'META-INF/LICENSE.txt', 'META-INF/license.txt', 'META-INF/NOTICE', 'META-INF/NOTICE.txt', 'META-INF/notice.txt', 'META-INF/ASL2.0', 'META-INF/io.netty.versions.properties', 'META-INF/INDEX.LIST']
+        }
     }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 
@@ -197,51 +192,52 @@ dependencies {
     implementation "io.insert-koin:koin-androidx-compose:$koin_version"
     testImplementation "io.insert-koin:koin-test:$koin_version"
 
-    implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.exifinterface:exifinterface:1.3.2'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation "androidx.work:work-runtime-ktx:2.7.1"
+    implementation 'androidx.exifinterface:exifinterface:1.3.7'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation "androidx.work:work-runtime-ktx:2.9.0"
 
     // Compose
-    implementation "androidx.compose.runtime:runtime:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.foundation:foundation:$compose_version"
-    implementation "androidx.compose.foundation:foundation-layout:$compose_version"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.animation:animation:$compose_version"
-    implementation "androidx.activity:activity-compose:1.3.0"
-    implementation "androidx.navigation:navigation-compose:2.4.1"
+    def compose_ui_version = "1.6.7"
+    implementation "androidx.compose.runtime:runtime:$compose_ui_version"
+    implementation "androidx.compose.runtime:runtime-livedata:$compose_ui_version"
+    implementation "androidx.compose.foundation:foundation:$compose_ui_version"
+    implementation "androidx.compose.foundation:foundation-layout:$compose_ui_version"
+    implementation "androidx.compose.ui:ui:$compose_ui_version"
+    implementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
+    implementation "androidx.compose.material:material:$compose_ui_version"
+    implementation "androidx.compose.animation:animation:$compose_ui_version"
+    implementation "androidx.activity:activity-compose:1.9.0"
+    implementation "androidx.navigation:navigation-compose:2.7.7"
 
     //Permissions management library for Jetpack Compose
-    implementation "com.google.accompanist:accompanist-permissions:0.21.1-beta"
-    
+    implementation "com.google.accompanist:accompanist-permissions:0.34.0"
+
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.3.2'
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-datetime:0.5.0'
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 
     //Database
-    implementation 'androidx.room:room-runtime:2.4.0-beta01'
-    implementation 'androidx.room:room-ktx:2.4.0-beta01'
-    kapt "androidx.room:room-compiler:2.4.0-beta01"
+    implementation 'androidx.room:room-runtime:2.6.1'
+    implementation 'androidx.room:room-ktx:2.6.1'
+    kapt "androidx.room:room-compiler:2.6.1"
 
 
     api "com.squareup.retrofit2:converter-gson:${retrofit2Version}"
     implementation "com.squareup.retrofit2:retrofit:${retrofit2Version}"
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
 
     // CameraX core library
-    def camerax_version = "1.0.0"
+    def camerax_version = "1.3.4"
     // CameraX view library
-    def camerax_view_version = "1.0.0-alpha24"
+    def camerax_view_version = "1.3.4"
     // CameraX extensions library
-    def camerax_ext_version = "1.0.0-alpha24"
+    def camerax_ext_version = "1.3.4"
     implementation "androidx.camera:camera-core:$camerax_version"
     // If you want to use Camera2 extensions
     implementation "androidx.camera:camera-camera2:$camerax_version"
@@ -252,28 +248,28 @@ dependencies {
     // If you to use Camera Extensions
     implementation "androidx.camera:camera-extensions:$camerax_ext_version"
 
-    api 'com.jakewharton.timber:timber:4.7.1'
+    api 'com.jakewharton.timber:timber:5.0.1'
     implementation "androidx.legacy:legacy-support-v4:${androidSupportVersion}"
 
-    implementation platform('com.google.firebase:firebase-bom:25.10.0')
-    implementation 'com.google.firebase:firebase-analytics:18.0.2'
-    implementation 'com.google.firebase:firebase-crashlytics-ktx:17.3.1'
-    implementation 'com.google.firebase:firebase-auth-ktx:20.0.2'
-    implementation 'com.google.firebase:firebase-iid:21.0.1'
+    implementation platform('com.google.firebase:firebase-bom:32.7.4')
+    implementation 'com.google.firebase:firebase-analytics'
+    implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-auth-ktx'
+    implementation 'com.google.firebase:firebase-iid:21.1.0'
 
-    testImplementation "io.mockk:mockk:1.10.0"
-    testImplementation "junit:junit:4.13.1"
-    testImplementation "androidx.room:room-testing:2.2.6"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9"
-    testImplementation "androidx.arch.core:core-testing:2.1.0"
-    androidTestImplementation "com.android.support.test:runner:1.0.2"
-    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.2"
+    testImplementation "io.mockk:mockk:1.13.9"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "androidx.room:room-testing:2.6.1"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3"
+    testImplementation "androidx.arch.core:core-testing:2.2.0"
+    androidTestImplementation "androidx.test:runner:1.5.2"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
 }
 
 configurations.all {
     resolutionStrategy {
         preferProjectModules()
-        force 'com.google.code.gson:gson:2.8.5'
+        force 'com.google.code.gson:gson:2.10.1'
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "org.greenstand.android.TreeTracker"
         minSdk 21
         targetSdk 35
-        versionCode 195
+        versionCode 198
         versionName "2.1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/9.json
+++ b/app/schemas/org.greenstand.android.TreeTracker.database.AppDatabase/9.json
@@ -1,0 +1,983 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "81c83c33d884d8e56a2d801f98bc0cd8",
+    "entities": [
+      {
+        "tableName": "planter_check_in",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`planter_info_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `created_at` INTEGER NOT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`planter_info_id`) REFERENCES `planter_info`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "planterInfoId",
+            "columnName": "planter_info_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_planter_check_in_planter_info_id",
+            "unique": false,
+            "columnNames": [
+              "planter_info_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_check_in_planter_info_id` ON `${TABLE_NAME}` (`planter_info_id`)"
+          },
+          {
+            "name": "index_planter_check_in_local_photo_path",
+            "unique": false,
+            "columnNames": [
+              "local_photo_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_check_in_local_photo_path` ON `${TABLE_NAME}` (`local_photo_path`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "planter_info",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_info_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "planter_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`planter_identifier` TEXT NOT NULL, `first_name` TEXT NOT NULL, `last_name` TEXT NOT NULL, `organization` TEXT, `phone` TEXT, `email` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, `record_uuid` TEXT NOT NULL DEFAULT '', `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "identifier",
+            "columnName": "planter_identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recordUuid",
+            "columnName": "record_uuid",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_planter_info_planter_identifier",
+            "unique": false,
+            "columnNames": [
+              "planter_identifier"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_info_planter_identifier` ON `${TABLE_NAME}` (`planter_identifier`)"
+          },
+          {
+            "name": "index_planter_info_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_planter_info_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "tree_attribute",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `tree_capture_id` INTEGER NOT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`tree_capture_id`) REFERENCES `tree_capture`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeCaptureId",
+            "columnName": "tree_capture_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_attribute_tree_capture_id",
+            "unique": false,
+            "columnNames": [
+              "tree_capture_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_attribute_tree_capture_id` ON `${TABLE_NAME}` (`tree_capture_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "tree_capture",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "tree_capture_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tree_capture",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `planter_checkin_id` INTEGER NOT NULL, `local_photo_path` TEXT, `photo_url` TEXT, `note_content` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `accuracy` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `bundle_id` TEXT, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`planter_checkin_id`) REFERENCES `planter_check_in`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "planterCheckInId",
+            "columnName": "planter_checkin_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localPhotoPath",
+            "columnName": "local_photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "noteContent",
+            "columnName": "note_content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_capture_planter_checkin_id",
+            "unique": false,
+            "columnNames": [
+              "planter_checkin_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_planter_checkin_id` ON `${TABLE_NAME}` (`planter_checkin_id`)"
+          },
+          {
+            "name": "index_tree_capture_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_capture_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "planter_check_in",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "planter_checkin_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "location_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`json_value` TEXT NOT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "locationDataJson",
+            "columnName": "json_value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_location_data_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_data_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `origin_user_id` TEXT NOT NULL, `origin_wallet` TEXT NOT NULL, `destination_wallet` TEXT NOT NULL, `start_time` TEXT NOT NULL, `end_time` TEXT, `organization` TEXT, `uploaded` INTEGER NOT NULL, `bundle_id` TEXT, `device_config_id` INTEGER, `note` TEXT, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`device_config_id`) REFERENCES `device_config`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originUserId",
+            "columnName": "origin_user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originWallet",
+            "columnName": "origin_wallet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationWallet",
+            "columnName": "destination_wallet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceConfigId",
+            "columnName": "device_config_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_session_origin_wallet",
+            "unique": false,
+            "columnNames": [
+              "origin_wallet"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_session_origin_wallet` ON `${TABLE_NAME}` (`origin_wallet`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "device_config",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "device_config_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "user",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `wallet` TEXT NOT NULL, `first_name` TEXT NOT NULL, `last_name` TEXT NOT NULL, `phone` TEXT, `email` TEXT, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `bundle_id` TEXT, `photo_path` TEXT NOT NULL, `photo_url` TEXT DEFAULT NULL, `power_user` INTEGER NOT NULL DEFAULT 0, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wallet",
+            "columnName": "wallet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "first_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "last_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoPath",
+            "columnName": "photo_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "powerUser",
+            "columnName": "power_user",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_user_wallet",
+            "unique": false,
+            "columnNames": [
+              "wallet"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_wallet` ON `${TABLE_NAME}` (`wallet`)"
+          },
+          {
+            "name": "index_user_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_user_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "location",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`json_value` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `uploaded` INTEGER NOT NULL, `create_at` INTEGER NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `session`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "locationDataJson",
+            "columnName": "json_value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "create_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_location_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_location_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_location_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "tree",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `session_id` INTEGER NOT NULL, `photo_path` TEXT, `photo_url` TEXT, `note` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `uploaded` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `bundle_id` TEXT DEFAULT NULL, `extra_attributes` TEXT DEFAULT NULL, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`session_id`) REFERENCES `session`(`_id`) ON UPDATE CASCADE ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoPath",
+            "columnName": "photo_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "extraAttributes",
+            "columnName": "extra_attributes",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_tree_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          },
+          {
+            "name": "index_tree_uploaded",
+            "unique": false,
+            "columnNames": [
+              "uploaded"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_tree_uploaded` ON `${TABLE_NAME}` (`uploaded`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "NO ACTION",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "device_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `app_version` TEXT NOT NULL, `app_build` INTEGER NOT NULL, `os_version` TEXT NOT NULL, `sdk_version` INTEGER NOT NULL, `logged_at` TEXT NOT NULL, `uploaded` INTEGER NOT NULL, `bundle_id` TEXT, `_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appVersion",
+            "columnName": "app_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appBuild",
+            "columnName": "app_build",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "osVersion",
+            "columnName": "os_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sdkVersion",
+            "columnName": "sdk_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loggedAt",
+            "columnName": "logged_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "uploaded",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bundleId",
+            "columnName": "bundle_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "organization",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` TEXT NOT NULL, `version` INTEGER NOT NULL, `name` TEXT NOT NULL, `wallet_id` TEXT NOT NULL, `capture_setup_flow_json` TEXT NOT NULL, `capture_flow_json` TEXT NOT NULL, PRIMARY KEY(`_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "walletId",
+            "columnName": "wallet_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureSetupFlowJson",
+            "columnName": "capture_setup_flow_json",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "captureFlowJson",
+            "columnName": "capture_flow_json",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '81c83c33d884d8e56a2d801f98bc0cd8')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.greenstand.android.TreeTracker"
+    xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
     <uses-feature
@@ -10,12 +10,16 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".application.TreeTrackerApplication"
@@ -26,7 +30,8 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
-        android:hardwareAccelerated="true">
+        android:hardwareAccelerated="true"
+        android:enableOnBackInvokedCallback="true">
 
         <uses-library android:name="org.apache.http.legacy" android:required="false"/>
 
@@ -77,6 +82,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths"/>
         </provider>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
         <service
             android:name=".background.SyncService"

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/ImageCaptureActivity.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.CompositionLocalProvider
@@ -60,6 +61,7 @@ class ImageCaptureActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         val captureSelfie = intent.extras?.getBoolean(SELFIE_MODE, false) ?: false

--- a/app/src/main/java/org/greenstand/android/TreeTracker/activities/TreeTrackerActivity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/activities/TreeTrackerActivity.kt
@@ -2,8 +2,9 @@ package org.greenstand.android.TreeTracker.activities
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.activity.enableEdgeToEdge
 import org.greenstand.android.TreeTracker.models.LanguageSwitcher
 import org.greenstand.android.TreeTracker.models.TreeTrackerViewModelFactory
 import org.greenstand.android.TreeTracker.root.Root
@@ -18,9 +19,15 @@ class TreeTrackerActivity : ComponentActivity() {
     private val viewModelFactory: TreeTrackerViewModelFactory by inject()
     private val gpsUtils: GpsUtils by inject()
 
-
-    @OptIn(ExperimentalComposeApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(
+                scrim = android.graphics.Color.argb(128, 0, 0, 0)
+            ),
+            navigationBarStyle = SystemBarStyle.dark(
+                scrim = android.graphics.Color.argb(128, 0, 0, 0)
+            )
+        )
         super.onCreate(savedInstanceState)
 
         languageSwitcher.applyCurrentLanguage(this)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/background/SyncNotification.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/background/SyncNotification.kt
@@ -3,6 +3,7 @@ package org.greenstand.android.TreeTracker.background
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -34,7 +35,15 @@ class SyncNotificationManager(
             .addAction(android.R.drawable.ic_delete, applicationContext.getString(R.string.cancel), intent)
             .setProgress(0, 0, true)
 
-        return ForegroundInfo(NOTIFICATION_ID, builder.build())
+        return ForegroundInfo(
+            NOTIFICATION_ID,
+            builder.build(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            }
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/background/TreeSyncWorker.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/background/TreeSyncWorker.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
@@ -61,6 +62,14 @@ class TreeSyncWorker(
             .setVisibility(NotificationCompat.VISIBILITY_SECRET)
             .setContentText(applicationContext.getString(R.string.uploading_trees))
             .build()
-        return ForegroundInfo(1337, notification)
+        return ForegroundInfo(
+            1337,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            } else {
+                0
+            }
+        )
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/ImageReviewScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/ImageReviewScreen.kt
@@ -23,6 +23,7 @@ fun ImageReviewScreen(photoPath: String) {
     val activity = LocalContext.current as Activity
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         bottomBar = {
             Row(
                 modifier = Modifier

--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/SelfieScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/SelfieScreen.kt
@@ -37,6 +37,7 @@ fun SelfieScreen() {
 
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 centerAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -81,6 +82,7 @@ fun TreeCaptureScreen(
     }
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         bottomBar = {
             ActionBar(
                 modifier = Modifier.background(color = AppColors.Gray),

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
@@ -87,7 +87,7 @@ class TreeCaptureViewModel(
 class TreeCaptureViewModelFactory(private val profilePicUrl: String)
     : ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return TreeCaptureViewModel(profilePicUrl, get(), get(), get(), get(),get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeImageReviewScreen.kt
@@ -31,6 +31,7 @@ fun TreeImageReviewScreen(
     val scope = rememberCoroutineScope()
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 centerAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -20,7 +21,6 @@ import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
@@ -59,7 +59,6 @@ import org.greenstand.android.TreeTracker.view.DepthSurfaceShape
 import org.greenstand.android.TreeTracker.view.LanguageButton
 import org.greenstand.android.TreeTracker.view.TopBarTitle
 
-@OptIn(ExperimentalComposeApi::class)
 @Composable
 fun DashboardScreen(
     viewModel: DashboardViewModel = viewModel(factory = LocalViewModelFactory.current),
@@ -81,6 +80,7 @@ fun DashboardScreen(
     }
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             DashboardTopBar(navController)
         },
@@ -130,8 +130,9 @@ fun DashboardScreen(
                     verticalArrangement = Arrangement.SpaceBetween,
                 ) {
                     DashboardUploadProgressBar(
-                        progress = (state.treesRemainingToSync)
-                            .toFloat() / (state.totalTreesToSync),
+                        progress = if (state.totalTreesToSync > 0)
+                            (state.treesRemainingToSync).toFloat() / (state.totalTreesToSync)
+                        else 0f,
                         modifier = Modifier.weight(1f),
                     )
                     Text(
@@ -197,7 +198,6 @@ fun DashboardTopBar(navController: NavController) {
     )
 }
 
-@ExperimentalComposeApi
 @Composable
 fun DashboardUploadProgressBar(
     progress: Float,
@@ -235,7 +235,6 @@ fun DashboardUploadProgressBar(
     }
 }
 
-@ExperimentalComposeApi
 @Composable
 fun DashBoardButton(
     text: String,
@@ -284,7 +283,6 @@ fun DashBoardButton(
     }
 }
 
-@ExperimentalComposeApi
 @Preview
 @Composable
 fun DashboardScreen_Preview(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardViewModel.kt
@@ -97,6 +97,7 @@ class DashboardViewModel(
                 showSnackBar?.invoke(R.string.sync_preparing)
                 _isSyncing = true
             }
+            null -> { /* no work info available */ }
         }
     }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/AppDatabase.kt
@@ -7,6 +7,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import org.greenstand.android.TreeTracker.database.entity.DeviceConfigEntity
+import org.greenstand.android.TreeTracker.database.entity.OrganizationEntity
 import org.greenstand.android.TreeTracker.database.entity.LocationEntity
 import org.greenstand.android.TreeTracker.database.entity.SessionEntity
 import org.greenstand.android.TreeTracker.database.entity.TreeEntity
@@ -18,7 +19,7 @@ import org.greenstand.android.TreeTracker.database.legacy.entity.TreeAttributeEn
 import org.greenstand.android.TreeTracker.database.legacy.entity.TreeCaptureEntity
 
 @Database(
-    version = 8,
+    version = 9,
     exportSchema = true,
     entities = [
         PlanterCheckInEntity::class,
@@ -31,9 +32,11 @@ import org.greenstand.android.TreeTracker.database.legacy.entity.TreeCaptureEnti
         LocationEntity::class,
         TreeEntity::class,
         DeviceConfigEntity::class,
+        OrganizationEntity::class,
     ],
     autoMigrations = [
-        AutoMigration(from = 7, to = 8)
+        AutoMigration(from = 7, to = 8),
+        AutoMigration(from = 8, to = 9),
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/OrganizationEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/OrganizationEntity.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Treetracker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.greenstand.android.TreeTracker.database.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "organization")
+class OrganizationEntity(
+    @PrimaryKey
+    @ColumnInfo(name = "_id")
+    var id: String,
+    @ColumnInfo(name = "version")
+    var version: Int,
+    @ColumnInfo(name = "name")
+    var name: String,
+    @ColumnInfo(name = "wallet_id")
+    var walletId: String,
+    @ColumnInfo(name = "capture_setup_flow_json")
+    val captureSetupFlowJson: String,
+    @ColumnInfo(name = "capture_flow_json")
+    val captureFlowJson: String,
+)

--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/SessionEntity.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/entity/SessionEntity.kt
@@ -38,6 +38,8 @@ data class SessionEntity(
     var bundleId: String? = null,
     @ColumnInfo(name = "device_config_id")
     var deviceConfigId: Long? = null,
+    @ColumnInfo(name = "note")
+    var note: String? = null,
 ) {
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name = "_id")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguageSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguageSelectScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Scaffold
@@ -41,6 +42,7 @@ fun LanguageSelectScreen(
     val activity = LocalContext.current as Activity
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             LanguageTopBar()
         },

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/announcementmessage/AnnouncementScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/announcementmessage/AnnouncementScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -50,6 +51,7 @@ fun AnnouncementScreen(
     val navController = LocalNavHostController.current
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 centerAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/announcementmessage/AnnouncementViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/announcementmessage/AnnouncementViewModel.kt
@@ -50,7 +50,7 @@ class AnnouncementViewModelFactory(
 ) :
     ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return AnnouncementViewModel(messageId, get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/directmessages/ChatScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/directmessages/ChatScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -68,6 +69,7 @@ fun ChatScreen(
     val navController: NavHostController = LocalNavHostController.current
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 leftAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/directmessages/ChatViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/directmessages/ChatViewModel.kt
@@ -86,7 +86,7 @@ class ChatViewModel(
 class ChatViewModelFactory(private val userId: Long, private val otherChatIdentifier: String) :
     ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return ChatViewModel(userId, otherChatIdentifier, get(), get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/individualmeassagelist/IndividualMessageListScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/individualmeassagelist/IndividualMessageListScreen.kt
@@ -3,9 +3,10 @@ package org.greenstand.android.TreeTracker.messages.individualmeassagelist
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,6 +38,7 @@ fun IndividualMessageListScreen(
     val state by viewModel.state.observeAsState(IndividualMessageListState())
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 leftAction = {
@@ -80,7 +82,7 @@ fun IndividualMessageListScreen(
         }
     ) {
         LazyVerticalGrid(
-            cells = GridCells.Fixed(2),
+            columns = GridCells.Fixed(2),
             modifier = Modifier.padding(it), // Padding for bottom bar.
             contentPadding = PaddingValues(start = 8.dp, end = 8.dp, top = 10.dp)
         ) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/individualmeassagelist/IndividualMessageListViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/individualmeassagelist/IndividualMessageListViewModel.kt
@@ -77,7 +77,7 @@ class IndividualMessageListViewModel(
 class IndividualMessageListViewModelFactory(private val userId: Long)
     : ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return IndividualMessageListViewModel(userId, get(), get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/survey/SurveyScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/survey/SurveyScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -39,6 +40,7 @@ fun SurveyScreen(
     val scope = rememberCoroutineScope()
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 centerAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/messages/survey/SurveyViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/messages/survey/SurveyViewModel.kt
@@ -93,7 +93,7 @@ class SurveyViewModel(
 class SurveyViewModelFactory(private val messageId: String)
     : ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return SurveyViewModel(messageId, get(), get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeTrackerViewModelFactory.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/TreeTrackerViewModelFactory.kt
@@ -19,7 +19,7 @@ import org.koin.core.component.get
 @Suppress("UNCHECKED_CAST")
 class TreeTrackerViewModelFactory : ViewModelProvider.NewInstanceFactory(), KoinComponent {
 
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return when {
             modelClass.isAssignableFrom(UserSelectViewModel::class.java) -> get<UserSelectViewModel>() as T
             modelClass.isAssignableFrom(DashboardViewModel::class.java) -> get<DashboardViewModel>() as T

--- a/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -46,6 +47,7 @@ fun AddOrgScreen(
     val state by viewModel.state.observeAsState(AddOrgState())
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         bottomBar = {
             ActionBar(
                 leftAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/AddOrgViewModel.kt
@@ -80,7 +80,7 @@ class AddOrgViewModelFactory(
     private val destinationWallet: String)
     : ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return AddOrgViewModel(userId, destinationWallet, get(), get(), get(), get(), get()) as T
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/OrgPickerScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/orgpicker/OrgPickerScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -43,7 +44,9 @@ fun OrgPickerScreen(viewModel: OrgPickerViewModel = viewModel(factory = LocalVie
         }
     }
 
-    Scaffold {
+    Scaffold(
+        modifier = Modifier.systemBarsPadding(),
+    ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/permissions/Permissions.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/permissions/Permissions.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -12,7 +13,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
+import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.accompanist.permissions.shouldShowRationale
 import android.provider.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
@@ -35,11 +38,14 @@ fun PermissionRequest(
     val navController = LocalNavHostController.current
     val state by viewModel.state.observeAsState(PermissionItemsState())
     val permissionsState = rememberMultiplePermissionsState(
-        permissions = listOf(
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.CAMERA,
-        )
+        permissions = buildList {
+            add(Manifest.permission.ACCESS_COARSE_LOCATION)
+            add(Manifest.permission.ACCESS_FINE_LOCATION)
+            add(Manifest.permission.CAMERA)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
     )
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(
@@ -61,8 +67,8 @@ fun PermissionRequest(
         when (perm.permission) {
             Manifest.permission.CAMERA -> {
                 when {
-                    perm.hasPermission -> {}
-                    perm.shouldShowRationale -> {
+                    perm.status.isGranted -> {}
+                    perm.status.shouldShowRationale -> {
                         CustomDialog(
                             title = stringResource(R.string.accept_camera_permission_header),
                             textContent = stringResource(R.string.accept_camera_permission_message),
@@ -82,13 +88,13 @@ fun PermissionRequest(
             }
             Manifest.permission.ACCESS_FINE_LOCATION -> {
                 when {
-                    perm.hasPermission -> {
+                    perm.status.isGranted -> {
                         viewModel.isLocationEnabled()
                         if (state.isLocationEnabled == false) {
                             enableLocation()
                         }
                     }
-                    perm.shouldShowRationale -> {
+                    perm.status.shouldShowRationale -> {
                         LocationRationaleDialog(navController = navController, perm = perm)
                     }
                     else -> {
@@ -98,19 +104,23 @@ fun PermissionRequest(
             }
             Manifest.permission.ACCESS_COARSE_LOCATION -> {
                 when {
-                    perm.hasPermission -> {
+                    perm.status.isGranted -> {
                         viewModel.isLocationEnabled()
                         if (state.isLocationEnabled == false) {
                             enableLocation()
                         }
                     }
-                    perm.shouldShowRationale -> {
+                    perm.status.shouldShowRationale -> {
                         LocationRationaleDialog(navController = navController, perm = perm)
                     }
                     else -> {
                         PermissionDeniedPermanentlyDialog(navController)
                     }
                 }
+            }
+            Manifest.permission.POST_NOTIFICATIONS -> {
+                // Notification permission is requested automatically via the multi-permission request.
+                // No rationale dialog needed — if denied, sync will still work but without notifications.
             }
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/preferences/Preferences.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/preferences/Preferences.kt
@@ -13,7 +13,7 @@ class Preferences(
     private val prefUpdateFlow: MutableSharedFlow<String> = MutableSharedFlow(replay = 1)
     private val preferenceChangeListener: SharedPreferences.OnSharedPreferenceChangeListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            prefUpdateFlow.tryEmit(key)
+            key?.let { prefUpdateFlow.tryEmit(it) }
         }
 
     init {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/root/Host.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/root/Host.kt
@@ -1,15 +1,12 @@
 package org.greenstand.android.TreeTracker.root
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.NavHost
-import androidx.navigation.get
+import androidx.navigation.compose.composable
 import org.greenstand.android.TreeTracker.models.NavRoute
 import org.greenstand.android.TreeTracker.view.TreeTrackerTheme
 
-@ExperimentalComposeApi
 @Composable
 fun Host() {
 
@@ -41,15 +38,11 @@ fun Host() {
 }
 
 fun NavGraphBuilder.addNavRoute(navRoute: NavRoute) {
-    addDestination(
-        ComposeNavigator.Destination(provider[ComposeNavigator::class], navRoute.content).apply {
-            this.route = navRoute.route
-            navRoute.arguments.forEach { (argumentName, argument) ->
-                addArgument(argumentName, argument)
-            }
-            navRoute.deepLinks.forEach { deepLink ->
-                addDeepLink(deepLink)
-            }
-        }
-    )
+    composable(
+        route = navRoute.route,
+        arguments = navRoute.arguments,
+        deepLinks = navRoute.deepLinks,
+    ) { backStackEntry ->
+        navRoute.content(backStackEntry)
+    }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
@@ -2,7 +2,6 @@ package org.greenstand.android.TreeTracker.root
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.compositionLocalOf
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
@@ -11,7 +10,6 @@ import org.greenstand.android.TreeTracker.models.TreeTrackerViewModelFactory
 val LocalViewModelFactory = compositionLocalOf<TreeTrackerViewModelFactory> { error { "No active ViewModel factory found!" } }
 val LocalNavHostController = compositionLocalOf<NavHostController> { error { "No NavHostController found!" } }
 
-@ExperimentalComposeApi
 @Composable
 fun Root(viewModelFactory: TreeTrackerViewModelFactory) {
     val navController = rememberNavController()

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/CredentialEntryView.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -79,6 +80,7 @@ fun CredentialEntryView(viewModel: SignupViewModel, state: SignUpState) {
     val snackBarHostState = remember { SnackbarHostState() }
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 centerAction = { TopBarTitle() },

--- a/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/signup/NameEntryView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -61,6 +62,7 @@ fun NameEntryView(viewModel: SignupViewModel, state: SignUpState) {
     }
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 centerAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/splash/SplashScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/splash/SplashScreen.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -69,7 +70,9 @@ fun SplashScreen(
         painter = painterResource(id = R.drawable.splash),
         contentDescription = null,
         contentScale = ContentScale.Crop,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .systemBarsPadding()
+            .fillMaxSize()
     )
 }
 

--- a/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelect.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/userselect/UserSelect.kt
@@ -3,9 +3,10 @@ package org.greenstand.android.TreeTracker.userselect
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.GridCells
-import androidx.compose.foundation.lazy.LazyVerticalGrid
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,6 +42,7 @@ fun UserSelect(
     val state by viewModel.state.observeAsState(UserSelectState())
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         bottomBar = {
             ActionBar(
                 centerAction = {
@@ -79,7 +81,7 @@ fun UserSelect(
         }
     ) {
         LazyVerticalGrid(
-            cells = GridCells.Fixed(2),
+            columns = GridCells.Fixed(2),
             modifier = Modifier.padding(it), // Padding for bottom bar.
             contentPadding = PaddingValues(start = 8.dp, end = 8.dp, top = 10.dp)
         ) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/utilities/GpsUtilities.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/utilities/GpsUtilities.kt
@@ -2,11 +2,10 @@ package org.greenstand.android.TreeTracker.utilities
 
 import android.content.Context
 import android.location.LocationManager
-import androidx.activity.ComponentActivity
 
 class GpsUtils(val context: Context) {
     fun hasGPSDevice(): Boolean {
-        val locationManager = context.getSystemService(ComponentActivity.LOCATION_SERVICE) as LocationManager
+        val locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
         val locationProviders = locationManager.allProviders
         return locationProviders.contains(LocationManager.GPS_PROVIDER)
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/WalletSelectScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -56,6 +57,7 @@ fun WalletSelectScreen(
     val scope = rememberCoroutineScope()
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         topBar = {
             ActionBar(
                 leftAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletScreen.kt
@@ -3,6 +3,7 @@ package org.greenstand.android.TreeTracker.walletselect.addwallet
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -39,6 +40,7 @@ fun AddWalletScreen(
     val state by viewModel.state.observeAsState(AddWalletState())
 
     Scaffold(
+        modifier = Modifier.systemBarsPadding(),
         bottomBar = {
             ActionBar(
                 leftAction = {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/walletselect/addwallet/AddWalletViewModel.kt
@@ -44,7 +44,7 @@ class AddWalletViewModel(
 class AddWalletViewModelFactory(private val userId: Long)
     : ViewModelProvider.Factory, KoinComponent {
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return AddWalletViewModel(userId, get()) as T
     }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -21,4 +21,6 @@
 
     <color name="stop_red">#C62828</color>
 
+    <color name="windowBackground">#FF191C1F</color>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:windowBackground">@color/windowBackground</item>
     </style>
 
     <style name="AppTheme.NoActionBar">

--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,20 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.24'
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
-        classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.google.gms:google-services:4.4.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.9'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
-        classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.2.1'
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.7"
+        classpath 'org.jlleitschuh.gradle:ktlint-gradle:11.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -27,7 +26,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven {
             url "https://maven.google.com" // Google's Maven repository
         }
@@ -35,10 +33,10 @@ allprojects {
     }
 
     ext {
-        compose_version = "1.1.1"
-        koin_version= "3.2.0-beta-1"
+        compose_version = "1.5.14"
+        koin_version = "3.5.3"
         androidSupportVersion = '1.0.0'
-        retrofit2Version = '2.6.0'
+        retrofit2Version = '2.9.0'
         s3_production_identity_pool_id = "configure in treetracker.keys.properties"
         prod_treetracker_client_id = "configure in treetracker.keys.properties"
         prod_treetracker_client_secret = "configure in treetracker.keys.properties"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,15 +12,6 @@
 kotlin.code.style=official
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+android.nonTransitiveRClass=true
+org.gradle.jvmargs=-Xmx2048m
 org.gradle.warning.mode=all
-
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-
-
-
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Apr 17 14:55:21 EDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrade AGP 7.0.0 → 8.7.3, Gradle 7.0.2 → 8.9, Kotlin 1.6.10 → 1.9.24, and Compose 1.1 → 1.6.7 to support compileSdk/targetSdk 35
- Add foreground service type (`dataSync`) for API 34+, edge-to-edge support for API 35+, and `POST_NOTIFICATIONS` runtime permission for API 33+
- Fix divide-by-zero crash in dashboard progress bar when no trees are pending sync (Compose foundation now validates `progressSemantics` values aren't NaN)
- Bump DB schema from v8 → v9 to match master (adds `OrganizationEntity` table and `note` column to `SessionEntity`), ensuring users can safely migrate between this branch and master without Room version mismatch crashes
- Bump versionCode to 198

## Tested
- ✅ Clean install on device — no crashes
- ✅ Install over master (v9 schema) — no DB migration crash
- ✅ Upgrade back to master over this build — no DB migration crash
- ✅ Unit tests pass

## Test plan
- [ ] Verify app launches without crashes on fresh install
- [ ] Verify app launches without crashes when upgrading from master
- [ ] Verify tree capture flow works end-to-end
- [ ] Verify upload/sync works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)