### PR TITLE
Fix snackbar position to bottom with nav bar padding

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/dashboard/DashboardScreen.kt
@@ -153,14 +153,15 @@ fun Dashboard(
         snackbarHost = {
             SnackbarHost(hostState = it, modifier = Modifier
                 .fillMaxWidth()
-                .wrapContentHeight(Alignment.Top)) { snackBarData->
+                .navigationBarsPadding()
+                .wrapContentHeight(Alignment.Bottom)) { snackBarData->
                 val backgroundColor = Green
 
-                Box(modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp)) {
+                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
                     Snackbar(
                         contentColor = CustomTheme.textColors.darkText,
                         backgroundColor = backgroundColor,
-                        modifier = Modifier.align(Alignment.TopStart)
+                        modifier = Modifier.align(Alignment.BottomStart)
                     ) {
                         Text(text = snackBarData.message, fontWeight = FontWeight.Bold, fontSize = 20.sp, modifier = Modifier.padding(vertical = 15.dp))
                     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/view/SnackBar.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/view/SnackBar.kt
@@ -15,6 +15,7 @@
  */
 package org.greenstand.android.TreeTracker.view
 
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarHost
@@ -35,6 +36,7 @@ fun CustomSnackbar(
     backGroundColor: Color = AppColors.Green,
 ) {
     SnackbarHost(
+        modifier = Modifier.navigationBarsPadding(),
         hostState = snackbarHostState,
         snackbar = { data ->
             Snackbar(


### PR DESCRIPTION
## Summary
- Fixed snackbar rendering at the top of the screen instead of the bottom in `DashboardScreen`
- Added `navigationBarsPadding()` so the snackbar doesn't render behind the navigation bar in edge-to-edge mode
- Applied the same `navigationBarsPadding()` fix to the reusable `CustomSnackbar` component in `SnackBar.kt`

## Test plan
- [ ] Trigger a sync on the dashboard and verify the snackbar appears at the bottom
- [ ] Verify the snackbar is not obscured by the navigation bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)