### PR TITLE
Fix camera view extending behind bottom bar

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/camera/SelfieScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/camera/SelfieScreen.kt
@@ -67,15 +67,25 @@ fun SelfieScreen() {
                             viewModel.updateSelfieTutorialDialog(true)
                         }
                     )
+                },
+                centerAction = {
+                    CaptureButton(
+                        modifier = Modifier.align(Alignment.Center),
+                        onClick = {
+                            cameraControl.captureImage()
+                        },
+                        isEnabled = true
+                    )
                 }
             )
         }
-    ) {
+    ) { padding ->
         Camera(
             isSelfieMode = true,
             cameraControl = cameraControl,
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(padding)
                 .aspectRatio(1.0f),
             onImageCaptured = {
                 navController.navigate(ImageReviewRoute(photoPath = it.path))
@@ -84,7 +94,7 @@ fun SelfieScreen() {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(it)
+                .padding(padding)
                 .padding(bottom = 10.dp),
             contentAlignment = Alignment.BottomCenter
         ) {
@@ -95,12 +105,6 @@ fun SelfieScreen() {
                     }
                 )
             }
-            CaptureButton(
-                onClick = {
-                    cameraControl.captureImage()
-                },
-                isEnabled = true
-            )
         }
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -95,6 +95,7 @@ fun TreeCaptureScreen(
     }
 
     Scaffold(
+        backgroundColor = AppColors.Gray,
         bottomBar = {
             ActionBar(
                 modifier = Modifier
@@ -158,6 +159,9 @@ fun TreeCaptureScreen(
         Camera(
             isSelfieMode = false,
             cameraControl = cameraControl,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
             onImageCaptured = {
                 viewModel.onImageCaptured(it)
                 if (state.isLocationAvailable == true) {


### PR DESCRIPTION
## Summary
- Camera preview was rendering behind the bottom button bar on both tree capture and selfie screens due to edge-to-edge mode
- Applied scaffold padding to camera modifier so it stops at the bottom bar boundary
- Set `backgroundColor = AppColors.Gray` on `TreeCaptureScreen` Scaffold so the area below the camera shows the correct background
- Moved `CaptureButton` into the `ActionBar` `centerAction` on `SelfieScreen` so it aligns properly with the info button

## Test plan
- [ ] Open tree capture camera — verify camera preview does not extend behind the bottom button bar
- [ ] Open selfie camera — verify camera preview does not extend behind the bottom bar
- [ ] Verify capture button is centered and aligned with the info button on selfie screen
- [ ] Verify gray background shows beneath the bottom bar on tree capture screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)