### PR TITLE
fix: remove deprecated dependencies and bump outdated libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,7 +176,6 @@ repositories {
     maven {
         url "https://maven.google.com"
     }
-    maven { url 'https://maven.fabric.io/public' }
     mavenCentral()
 }
 
@@ -212,7 +211,6 @@ dependencies {
     implementation libs.coil.compose
 
     // Kotlin
-    implementation libs.kotlin.stdlib.jdk7
     implementation libs.kotlinx.coroutines.core
     implementation libs.kotlinx.coroutines.android
     implementation libs.kotlinx.coroutines.play.services
@@ -237,7 +235,6 @@ dependencies {
 
     // Logging
     api libs.timber
-    implementation libs.androidx.legacy.support.v4
 
     // Firebase
     implementation platform(libs.firebase.bom)

--- a/docs/tasks/task_11/README.md
+++ b/docs/tasks/task_11/README.md
@@ -1,0 +1,31 @@
+# Task 11: Dependency Cleanup Quick Wins
+
+## Summary
+Remove deprecated/dead dependencies and bump outdated libraries that are safe, non-breaking upgrades.
+
+## Changes
+
+### Removed (dead/deprecated)
+| Dependency | Reason |
+|-----------|--------|
+| `androidx.legacy:legacy-support-v4` | Deprecated, unmaintained, zero imports in codebase |
+| `kotlin-stdlib-jdk7` | Deprecated since Kotlin 1.8; merged into `kotlin-stdlib` |
+| `maven.fabric.io` repo | Fabric shut down in 2020; dead Maven repository |
+| `com.android.support.test:runner` | Old support library; replaced with `androidx.test:runner` |
+| `com.android.support.test.espresso:espresso-core` | Old support library; consolidated with AndroidX variant |
+
+### Version bumps
+| Library | Old | New | Notes |
+|---------|-----|-----|-------|
+| Gson | 2.8.5 | 2.13.2 | Bug fixes, performance improvements |
+| Timber | 4.7.1 | 5.0.1 | Rewritten in Kotlin, binary-compatible |
+| JUnit | 4.13.1 | 4.13.2 | Patch release |
+| Detekt | 1.18.0-RC2 | 1.23.8 | Ancient RC to latest stable |
+| Room Testing | 2.2.6 | 2.6.1 | Aligned with room-runtime version |
+| AndroidX Test Runner | 1.0.2 | 1.6.1 | Migrated to AndroidX coordinates |
+| AndroidX Test Espresso | 3.0.2/3.4.0 | 3.6.1 | Consolidated duplicate entries |
+| AndroidX Test JUnit | 1.1.3 | 1.2.1 | Minor version bump |
+
+## Verification
+- `./gradlew clean assembleDebug` - BUILD SUCCESSFUL
+- `./gradlew test` - all tests pass

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ googleServices = "4.4.2"
 firebaseCrashlytics = "2.9.9"
 ktlint = "11.0.0"
 spotless = "6.18.0"
-detekt = "1.18.0-RC2"
+detekt = "1.23.8"
 
 # AndroidX Core
 androidxCore = "1.13.1"
@@ -20,7 +20,6 @@ androidxMultidex = "2.0.1"
 androidxExifInterface = "1.3.2"
 androidxLifecycle = "2.8.7"
 androidxWork = "2.9.1"
-androidxLegacySupport = "1.0.0"
 
 # Compose
 compose = "1.7.5"
@@ -39,7 +38,7 @@ room = "2.6.1"
 # Networking
 retrofit = "2.11.0"
 okhttp = "4.9.3"
-gson = "2.8.5"
+gson = "2.13.2"
 
 # AWS
 awsSdk = "2.16.8"
@@ -53,19 +52,17 @@ cameraxExt = "1.4.1"
 koin = "3.5.6"
 
 # Logging
-timber = "4.7.1"
+timber = "5.0.1"
 
 # Firebase
 firebaseBom = "32.8.0"
 
 # Testing
-junit = "4.13.1"
+junit = "4.13.2"
 androidxTestCore = "1.5.0"
-androidxTestRunner = "1.0.2"
-androidxTestEspresso = "3.0.2"
-androidxTestJunit = "1.1.3"
-androidxTestEspressoNew = "3.4.0"
-androidxRoomTesting = "2.2.6"
+androidxTestRunner = "1.6.1"
+androidxTestEspresso = "3.6.1"
+androidxTestJunit = "1.2.1"
 androidxArchCoreTesting = "2.1.0"
 mockk = "1.13.12"
 robolectric = "4.16.1"
@@ -90,7 +87,6 @@ androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-view
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }
-androidx-legacy-support-v4 = { module = "androidx.legacy:legacy-support-v4", version.ref = "androidxLegacySupport" }
 
 # Compose
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
@@ -107,7 +103,6 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
 
 # Kotlin
-kotlin-stdlib-jdk7 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutines" }
@@ -120,7 +115,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
-androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "androidxRoomTesting" }
+androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 
 # Networking
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
@@ -173,10 +168,9 @@ firebase-installations = { module = "com.google.firebase:firebase-installations"
 # Testing
 junit = { module = "junit:junit", version.ref = "junit" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidxTestCore" }
-androidx-test-runner = { module = "com.android.support.test:runner", version.ref = "androidxTestRunner" }
-androidx-test-espresso-core = { module = "com.android.support.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspresso" }
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
-androidx-test-espresso-core-new = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxTestEspressoNew" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidxArchCoreTesting" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
## Summary
- **Remove dead dependencies**: `legacy-support-v4` (deprecated, zero imports), `kotlin-stdlib-jdk7` (merged into `kotlin-stdlib` since Kotlin 1.8), Fabric Maven repo (shut down 2020)
- **Migrate test libs to AndroidX**: Replaced old `com.android.support.test:runner` and `com.android.support.test.espresso:espresso-core` with proper `androidx.test` equivalents; consolidated duplicate espresso entries
- **Bump safe version upgrades**: Gson 2.8.5→2.13.2, Timber 4.7.1→5.0.1, Detekt 1.18.0-RC2→1.23.8, JUnit 4.13.1→4.13.2, AndroidX Test Runner 1.6.1, Espresso 3.6.1, Test JUnit 1.2.1
- **Fix room-testing version mismatch**: Aligned room-testing (was 2.2.6) with room-runtime (2.6.1)

## Changes by file

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Version bumps, removed deprecated lib entries, migrated test lib coordinates to AndroidX |
| `app/build.gradle` | Removed `kotlin-stdlib-jdk7`, `legacy-support-v4`, Fabric maven repo |
| `docs/tasks/task_11/` | Task documentation |

## Test plan
- [x] `./gradlew clean assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests pass
- [ ] Verify detekt still runs correctly with 1.23.8 (config is backwards-compatible)
- [ ] Smoke test on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)