### PR TITLE
feat: add UiEvent channel system to BaseViewModel

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodel/BaseViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodel/BaseViewModel.kt
@@ -29,8 +29,8 @@ abstract class BaseViewModel<S, A : Action>(
     private val _state = MutableStateFlow(initialState)
     val state: StateFlow<S> = _state.asStateFlow()
 
-    private val _events = Channel<UiEvent>(Channel.BUFFERED)
-    val events: Flow<UiEvent> = _events.receiveAsFlow()
+    private val _events = Channel<ConsumableEvent<UiEvent>>(Channel.BUFFERED)
+    val events: Flow<ConsumableEvent<UiEvent>> = _events.receiveAsFlow()
 
     protected val currentState: S get() = _state.value
 
@@ -39,7 +39,7 @@ abstract class BaseViewModel<S, A : Action>(
     }
 
     protected fun triggerEvent(event: UiEvent) {
-        _events.trySend(event)
+        _events.trySend(ConsumableEvent(event))
     }
 
     protected fun navigate(route: Any) {

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodel/HandleUiEvents.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodel/HandleUiEvents.kt
@@ -33,10 +33,12 @@ import timber.log.Timber
 fun <S, A : Action> HandleUiEvents(viewModel: BaseViewModel<S, A>) {
     val navController = LocalNavHostController.current
     LaunchedEffect(Unit) {
-        viewModel.events.collect { event ->
-            when (event) {
-                is NavigationEvent -> event.navigate(navController)
-                else -> Timber.w("Unhandled UiEvent: $event")
+        viewModel.events.collect { consumable ->
+            consumable.getContentIfNotConsumed()?.let { event ->
+                when (event) {
+                    is NavigationEvent -> event.navigate(navController)
+                    else -> Timber.w("Unhandled UiEvent: $event")
+                }
             }
         }
     }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/viewmodel/UiEvents.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/viewmodel/UiEvents.kt
@@ -16,6 +16,7 @@
 package org.greenstand.android.TreeTracker.viewmodel
 
 import androidx.navigation.NavHostController
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Base interface for one-shot UI events emitted by ViewModels.
@@ -33,3 +34,21 @@ interface UiEvent
 class NavigationEvent(
     val navigate: suspend NavHostController.() -> Unit,
 ) : UiEvent
+
+/**
+ * Thread-safe wrapper ensuring a [UiEvent] is consumed at most once.
+ *
+ * Events buffered in a [Channel] can outlive the collector that was meant to
+ * handle them (e.g. rotation, back-navigation to a screen whose ViewModel
+ * survived). Wrapping every event in [ConsumableEvent] guarantees that even
+ * if a stale event is delivered to a new collector, [getContentIfNotConsumed]
+ * returns `null` after the first access.
+ */
+class ConsumableEvent<out T : UiEvent>(
+    private val content: T,
+) {
+    private val consumed = AtomicBoolean(false)
+
+    /** Returns the event on the first call, `null` on every subsequent call. */
+    fun getContentIfNotConsumed(): T? = if (consumed.compareAndSet(false, true)) content else null
+}


### PR DESCRIPTION
## Summary

Adds a `Channel`-based one-shot event system to `BaseViewModel` so ViewModels can emit UI events (like navigation) that are consumed exactly once — avoiding infinite-loop bugs caused by `LaunchedEffect`-on-state navigation patterns.

Split out from #1210 as standalone infrastructure (PR 1 of 4).

- **`UiEvent`** interface + **`NavigationEvent`** class carrying a suspend `NavHostController.() -> Unit` lambda
- **`triggerEvent()`** on `BaseViewModel` for emitting events
- **`events: Flow<UiEvent>`** backed by a buffered `Channel` for consumption
- **`HandleUiEvents`** reusable composable — place near top of any screen to subscribe

### Design decisions vs #1210
- `NavigationEvent` is a regular `class`, not `data class` — lambda fields produce meaningless `equals`/`hashCode`
- `when` in `HandleUiEvents` has an `else` branch with `Timber.w` logging so new event types don't silently disappear
- Copyright year corrected to 2026

## Test plan
- [x] `ktlintCheck` passes
- [x] `compileDebugKotlin` succeeds
- [x] `testDebugUnitTest` all pass
- [ ] Verify no behavior change — this PR is purely additive, no screens use `HandleUiEvents` yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)