### PR TITLE
fix: resolve tree capture race condition between GPS and camera

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureScreen.kt
@@ -71,6 +71,7 @@ import org.greenstand.android.TreeTracker.view.TreeTrackerButton
 import org.greenstand.android.TreeTracker.view.TreeTrackerButtonShape
 import org.greenstand.android.TreeTracker.view.UserImageButton
 import org.greenstand.android.TreeTracker.view.dialogs.CustomDialog
+import org.greenstand.android.TreeTracker.viewmodel.HandleUiEvents
 
 @ExperimentalPermissionsApi
 @Composable
@@ -87,6 +88,8 @@ fun TreeCaptureScreen(
     cameraControl.imageScaleHeight = state.imageScalingHeight
 
     PermissionRequest()
+
+    HandleUiEvents(viewModel)
 
     BackHandler(enabled = true) {
         scope.launch {
@@ -165,11 +168,6 @@ fun TreeCaptureScreen(
                     .padding(padding),
             onImageCaptured = {
                 viewModel.handleAction(TreeCaptureAction.OnImageCaptured(it))
-                if (state.isLocationAvailable == true) {
-                    scope.launch {
-                        CaptureFlowScopeManager.nav.navForward(navController)
-                    }
-                }
             },
         )
         ActionBar(

--- a/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/capture/TreeCaptureViewModel.kt
@@ -18,8 +18,10 @@ package org.greenstand.android.TreeTracker.capture
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.greenstand.android.TreeTracker.devoptions.ConfigKeys
 import org.greenstand.android.TreeTracker.devoptions.Configurator
 import org.greenstand.android.TreeTracker.models.TreeCapturer
@@ -29,8 +31,10 @@ import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesParams
 import org.greenstand.android.TreeTracker.usecases.CreateFakeTreesUseCase
 import org.greenstand.android.TreeTracker.viewmodel.Action
 import org.greenstand.android.TreeTracker.viewmodel.BaseViewModel
+import org.greenstand.android.TreeTracker.viewmodel.NavigationEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
+import timber.log.Timber
 import java.io.File
 
 data class TreeCaptureState(
@@ -69,6 +73,8 @@ class TreeCaptureViewModel(
     private val createFakeTreesUseCase: CreateFakeTreesUseCase,
     private val configurator: Configurator,
 ) : BaseViewModel<TreeCaptureState, TreeCaptureAction>(TreeCaptureState(profilePicUrl = profilePicUrl)) {
+    private var pinLocationDeferred: CompletableDeferred<Boolean>? = null
+
     init {
         viewModelScope.launch(Dispatchers.Main) {
             val enabled = configurator.getBoolean(ConfigKeys.FORCE_IMAGE_SIZE)
@@ -87,14 +93,40 @@ class TreeCaptureViewModel(
     override fun handleAction(action: TreeCaptureAction) {
         when (action) {
             is TreeCaptureAction.CaptureLocation -> {
+                if (pinLocationDeferred != null) return
+                val deferred = CompletableDeferred<Boolean>()
+                pinLocationDeferred = deferred
                 viewModelScope.launch {
                     updateState { copy(isGettingLocation = true) }
                     val locationAvailable = treeCapturer.pinLocation()
+                    deferred.complete(locationAvailable)
                     updateState { copy(isLocationAvailable = locationAvailable, isGettingLocation = false) }
                 }
             }
             is TreeCaptureAction.OnImageCaptured -> {
-                treeCapturer.setImage(action.imageFile)
+                viewModelScope.launch {
+                    val locationAvailable =
+                        withTimeoutOrNull(GPS_WAIT_TIMEOUT_MS) {
+                            pinLocationDeferred?.await()
+                        }
+                    pinLocationDeferred = null
+                    when (locationAvailable) {
+                        true -> {
+                            treeCapturer.setImage(action.imageFile)
+                            triggerEvent(
+                                NavigationEvent { CaptureFlowScopeManager.nav.navForward(this) },
+                            )
+                        }
+                        false -> {
+                            Timber.w("GPS location unavailable, showing bad GPS dialog")
+                            updateState { copy(isLocationAvailable = false) }
+                        }
+                        null -> {
+                            Timber.w("Timed out waiting for GPS location")
+                            updateState { copy(isLocationAvailable = false) }
+                        }
+                    }
+                }
             }
             is TreeCaptureAction.UpdateBadGpsDialogState -> {
                 updateState { copy(isLocationAvailable = action.state) }
@@ -113,6 +145,10 @@ class TreeCaptureViewModel(
     }
 
     private suspend fun isFirstTrack(): Boolean = userRepo.getPowerUser()!!.numberOfTrees < 1
+
+    companion object {
+        private const val GPS_WAIT_TIMEOUT_MS = 30_000L
+    }
 }
 
 class TreeCaptureViewModelFactory(


### PR DESCRIPTION
## Summary

Fixes a crash where `setImage()` was called before `pinLocation()` completed, because camera capture and GPS pinning run concurrently. The camera could finish first, and `TreeCapturer.setImage()` would throw since `newTreeUuid` was still null.

Split out from #1210 as a focused bug fix (PR 2 of 4). Depends on #1218 (UiEvent system, now merged).

### What changed

**`TreeCaptureViewModel`**:
- `CaptureLocation` creates a `CompletableDeferred<Boolean>` that `OnImageCaptured` awaits before calling `setImage()`
- Double-dispatch guard: if `CaptureLocation` is already in flight, subsequent dispatches are ignored
- 30-second `withTimeoutOrNull` on the GPS wait to prevent indefinite hangs
- On GPS failure or timeout, the bad GPS dialog is shown instead of silently discarding the photo
- Navigation moved from Screen into ViewModel via `triggerEvent(NavigationEvent {...})`

**`TreeCaptureScreen`**:
- `HandleUiEvents(viewModel)` wired up to receive navigation events
- Removed inline `if (state.isLocationAvailable) { navForward() }` from `onImageCaptured` callback — this was the source of the race

### Issues addressed from #1210 review
- Silent photo discard → now shows bad GPS dialog
- Indefinite hang on `await()` → 30s timeout
- No synchronization on deferred → double-dispatch guard
- Navigation from composable callback → moved to ViewModel via UiEvent

## Test plan
- [ ] Tap capture → verify navigation to review screen works
- [ ] From review screen, navigate back → verify no infinite navigation loop
- [ ] Disable GPS / poor signal → verify bad GPS dialog appears (not silent discard)
- [ ] Rapid double-tap capture → verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)