### PR TITLE
fix: drop manifest screenOrientation portrait (#1171)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,18 +44,23 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+        <!-- Portrait orientation was previously locked here via android:screenOrientation="portrait".
+             Removed to satisfy Google Play policy: apps must not declare orientation or resizability
+             restrictions that block large-screen devices (tablets, foldables); Android 16+ may ignore
+             such manifest locks on those devices anyway, causing inconsistent UX. GitHub #1171. -->
+        <!-- android:screenOrientation="portrait" -->
         <activity android:name=".activities.ImageCaptureActivity"
                   android:configChanges="orientation"
                   android:label="@string/app_name"
-                  android:screenOrientation="portrait"
                   android:theme="@style/AppTheme.NoActionBar">
-            <!-- configure this activity to use portrait orientation -->
         </activity>
 
 
+        <!-- Same as ImageCaptureActivity above: manifest portrait lock removed for Play / large-screen
+             compliance (#1171). -->
+        <!-- android:screenOrientation="portrait" -->
         <activity
             android:name=".activities.TreeTrackerActivity"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize"
             android:launchMode="singleTask"
             android:theme="@style/AppTheme.NoActionBar"


### PR DESCRIPTION

## Summary

Removes manifest `android:screenOrientation="portrait"` from **`TreeTrackerActivity`** and **`ImageCaptureActivity`** so the app no longer declares orientation locks that conflict with **Google Play** guidance for **large screens** and **Android 16+** behavior. Previous values are preserved as **XML comments** with context (see `AndroidManifest.xml`).

**Fixes #1171**

---

## Checklist

- [x] **Issue first** — Tracked in #1171 (Google Play / large-screen orientation & resizability).
- [x] **Tests** — Not required for this change (manifest-only); no test updates.
- [ ] **Lint / analysis** — Run locally: `./codeAnalysis` (formatting + lint).
- [x] **Docs** — Not required for this manifest-only change.

---

## Verification (please review)

**Short screen recording attached** showing the app **rotating between portrait and landscape** on a Resizable emulator to see current behavior after removing the manifest lock.

**Landscape / large-screen notes (future work, not blocking this PR):**  
-
[Screen_recording_20260403_102559.webm](https://github.com/user-attachments/assets/9d6c5657-4ed1-4711-acf3-99fdb7a954b8)

-
[Screen_recording_20260403_102535.webm](https://github.com/user-attachments/assets/c6fca628-8d28-4481-837a-9e4559a07c72)

- 
[Screen_recording_20260403_102627.webm](https://github.com/user-attachments/assets/5bfb6edd-217f-48bd-bf11-4e9eb50835ba)


---

## Notes

- End users are still primarily **phones in portrait**; this change is to **satisfy Play policy** and avoid manifest restrictions on **tablets / foldables**. Follow-up UX polish for non-portrait layouts can be tracked separately.

---
