### PR TITLE
fix: pluralize 'photo' to 'photos' in Privacy Policy

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,7 +152,7 @@ Donor information: When you make a donation we collect information that is used 
         \n
 User Photos:
         \n
-GreenStand’s tree tracking program runs on the collection of time-stamped, geotagged photos. This information is stored in a secure database from which it is displayed in the form of a tree map. We also use this information to generate statistics related to tree planting. We are only interested in tree-related photos, please don’t send us anything else. With the proper use of this system, all photo taken will relate to environmental data and GreenStand does not consider or treat uploaded photos as “user data.” By using our mobile application you are agreeing to allow us to use your photos.
+GreenStand’s tree tracking program runs on the collection of time-stamped, geotagged photos. This information is stored in a secure database from which it is displayed in the form of a tree map. We also use this information to generate statistics related to tree planting. We are only interested in tree-related photos, please don’t send us anything else. With the proper use of this system, all photos taken will relate to environmental data and GreenStand does not consider or treat uploaded photos as “user data.” By using our mobile application you are agreeing to allow us to use your photos.
         \n
         \n
 User Data Deletion:


### PR DESCRIPTION
The Privacy Policy text under User Photos uses singular "photo" where plural "photos" is grammatically correct:

> With the proper use of this system, **all photo taken** will relate to environmental data...

Should read **"all photos taken"** to match the plural context (multiple photos are being discussed).

**Fix:** Changed `photo` → `photos` in `app/src/main/res/values/strings.xml` line 155.

Fixes #1271