### PR TITLE
Apply selected language before signup navigation

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguagePickerViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguagePickerViewModel.kt
@@ -50,11 +50,10 @@ class LanguagePickerViewModel(
     override fun handleAction(action: LanguagePickerAction) {
         when (action) {
             is LanguagePickerAction.SetLanguage -> {
+                languageSwitcher.setLanguage(action.language)
                 updateState { copy(currentLanguage = action.language) }
             }
-            is LanguagePickerAction.ConfirmLanguage -> {
-                state.value.currentLanguage?.let { languageSwitcher.setLanguage(it) }
-            }
+            is LanguagePickerAction.ConfirmLanguage -> { }
             else -> { }
         }
     }

--- a/docs/tasks/task_18/README.md
+++ b/docs/tasks/task_18/README.md
@@ -1,0 +1,5 @@
+# Fix signup language selection timing
+
+## Summary
+
+Language selection now applies the selected locale as soon as the user taps a language option. The next button no longer re-applies the locale immediately before navigating, which avoids racing app locale recreation against signup navigation.


### PR DESCRIPTION
The signup language picker now applies the selected locale when the user taps a language option instead of waiting until the next button is pressed. That keeps the locale update ahead of the navigation into the signup flow and avoids racing the app locale recreation against the next screen initialization. Closes #1172.