### PR TITLE
fix: pluralize 'photo' to 'photos' in Privacy Policy (#1273) (backport to 2.2.1)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,7 +152,7 @@ Donor information: When you make a donation we collect information that is used 
         \n
 User Photos:
         \n
-GreenStand’s tree tracking program runs on the collection of time-stamped, geotagged photos. This information is stored in a secure database from which it is displayed in the form of a tree map. We also use this information to generate statistics related to tree planting. We are only interested in tree-related photos, please don’t send us anything else. With the proper use of this system, all photo taken will relate to environmental data and GreenStand does not consider or treat uploaded photos as “user data.” By using our mobile application you are agreeing to allow us to use your photos.
+GreenStand’s tree tracking program runs on the collection of time-stamped, geotagged photos. This information is stored in a secure database from which it is displayed in the form of a tree map. We also use this information to generate statistics related to tree planting. We are only interested in tree-related photos, please don’t send us anything else. With the proper use of this system, all photos taken will relate to environmental data and GreenStand does not consider or treat uploaded photos as “user data.” By using our mobile application you are agreeing to allow us to use your photos.
         \n
         \n
 User Data Deletion:


### PR DESCRIPTION
Backport of #1273 to `releases/2.2.1`.

Cherry-picks `bdac81f` (originally merged to `master` 2026-04-21) onto the release branch. Issue #1271 is milestoned for 2.2.1 with the `2.2.1` label, but the master-side merge never reached the release branch — this PR closes that gap.

## What

One-line string change in `app/src/main/res/values/strings.xml` line 155: `all photo taken` → `all photos taken`.

## Why backport

Issue #1271 is on the 2.2.1 milestone. Without this cherry-pick, the typo ships in 2.2.1.

## Verification

- Cherry-pick applied cleanly (no merge conflicts).
- Diff matches the original merge commit.

Refs #1271, #1273. Same pattern as #1284 (which backported #1282 to this branch).