### PR TITLE
Fix LocationDataCapturer coroutine leak

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturer.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturer.kt
@@ -18,9 +18,11 @@ package org.greenstand.android.TreeTracker.models.location
 import android.location.Location
 import androidx.annotation.MainThread
 import androidx.lifecycle.Observer
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -56,6 +58,7 @@ class LocationDataCapturer(
     private var convergenceStatus: ConvergenceStatus? = null
     private var areLocationUpdatesOn: Boolean = false
     val percentageConvergenceObservers = mutableListOf<(Float) -> Unit>()
+    private val locationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     var newestPercentageConvergence: Float by Delegates.observable(0f) { _, oldValue, newValue ->
         // convergence percentage fluctuates so it is only updated when it increases
         if (newValue > oldValue) {
@@ -122,7 +125,7 @@ class LocationDataCapturer(
 
                 sessionTracker.currentSessionId?.let { currentSessionId ->
 
-                    MainScope().launch(Dispatchers.IO) {
+                    locationScope.launch {
                         val locationData =
                             LocationData(
                                 currentSessionId,
@@ -164,6 +167,7 @@ class LocationDataCapturer(
         }
         locationUpdateManager.locationUpdateLiveData.removeObserver(locationObserver)
         locationUpdateManager.stopLocationUpdates()
+        locationScope.coroutineContext.cancelChildren()
         areLocationUpdatesOn = false
     }
 

--- a/app/src/test/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturerTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/models/location/LocationDataCapturerTest.kt
@@ -22,10 +22,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import org.greenstand.android.TreeTracker.database.TreeTrackerDAO
 import org.greenstand.android.TreeTracker.models.ConvergenceConfiguration
@@ -40,6 +44,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class LocationDataCapturerTest {
     private lateinit var locationDataCapturer: LocationDataCapturer
@@ -95,6 +101,32 @@ class LocationDataCapturerTest {
 
         verify { liveData.observeForever(any<Observer<Location?>>()) }
     }
+
+    @Test
+    fun `WHEN GPS updates stop THEN pending location inserts are cancelled`() =
+        runTest {
+            val locationsLiveData = MutableLiveData<Location?>()
+            val insertCompleted = CountDownLatch(1)
+            every { locationUpdateManager.locationUpdateLiveData } returns locationsLiveData
+            every { sessionTracker.currentSessionId } returns 1L
+            every { timeProvider.currentTime() } returns Instant.fromEpochMilliseconds(1000)
+            coEvery { treeTrackerDAO.insertLocationData(any()) } coAnswers {
+                delay(500)
+                insertCompleted.countDown()
+                1L
+            }
+
+            locationDataCapturer.startGpsUpdates()
+            val location = mockk<Location>(relaxed = true)
+            every { location.latitude } returns 1.0
+            every { location.longitude } returns 2.0
+            every { location.accuracy } returns 3f
+
+            locationsLiveData.value = location
+            locationDataCapturer.stopGpsUpdates()
+
+            assertFalse(insertCompleted.await(1, TimeUnit.SECONDS))
+        }
 
     @Test
     fun turnOnTreeCaptureMode() {

--- a/docs/tasks/task_21/README.md
+++ b/docs/tasks/task_21/README.md
@@ -1,0 +1,19 @@
+# Task 21 - Fix LocationDataCapturer coroutine leak
+
+## Goal
+
+Fix issue #1231, where `LocationDataCapturer` created a new `MainScope()` for every
+location update and never cancelled those scopes.
+
+## Changes
+
+- Replaced per-update `MainScope()` creation with a class-level `CoroutineScope`.
+- Cancel pending location insert jobs when `stopGpsUpdates()` is called.
+- Added a regression test that fails with the old implementation because a pending
+  location insert can still complete after GPS updates stop.
+
+## Verification
+
+- Confirmed the regression test fails with the old `MainScope()` implementation.
+- `./gradlew.bat :app:testDebugUnitTest --tests "org.greenstand.android.TreeTracker.models.location.LocationDataCapturerTest.WHEN GPS updates stop THEN pending location inserts are cancelled"` passes with the fix.
+- `./gradlew.bat :app:testDebugUnitTest --tests "org.greenstand.android.TreeTracker.models.location.LocationDataCapturerTest"` passes.


### PR DESCRIPTION
Thank you for opening a Pull Request!

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests are added/updated (if necessary)
- [x] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
- [x] Appropriate docs were updated (if necessary)

Fixes #1231 🦕

## Summary
- Replace per-location-update `MainScope()` creation with a class-level coroutine scope
- Cancel pending location insert jobs when GPS updates stop
- Add a regression test for pending location inserts after `stopGpsUpdates()`

## Testing
- `./gradlew.bat :app:testDebugUnitTest --tests "org.greenstand.android.TreeTracker.models.location.LocationDataCapturerTest"`
- `./gradlew.bat spotlessApply ktlintFormat ktlintCheck detekt`