### PR TITLE
fix: re-hydrate OrgRepo on process-death restoration (2.2.1)

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/organization/OrgRepo.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/organization/OrgRepo.kt
@@ -49,6 +49,21 @@ class OrgRepo(
         Timber.tag("OrgRepo").d("Org settings: $currentOrg")
     }
 
+    /**
+     * Re-hydrate [currentOrg] from persisted state if it is missing.
+     *
+     * [currentOrg] lives only in memory, so it is lost on process death. When the OS
+     * restores the app into a deep screen (e.g. mid capture-setup flow) the splash
+     * screen — and therefore [init] — is bypassed, leaving [currentOrg] null. Calling
+     * this before the capture-setup flow is used reloads the org from the DB/prefs so
+     * [currentOrg] does not throw. No-op when already initialized.
+     */
+    suspend fun ensureInitialized() {
+        if (currentOrg == null) {
+            init()
+        }
+    }
+
     private fun defaultOrgEntity() =
         OrganizationEntity(
             id = DEFAULT_ORG_ID,

--- a/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
@@ -18,10 +18,18 @@ package org.greenstand.android.TreeTracker.root
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import org.greenstand.android.TreeTracker.models.TreeTrackerViewModelFactory
+import org.greenstand.android.TreeTracker.models.organization.OrgRepo
+import org.greenstand.android.TreeTracker.splash.Splash
+import org.koin.compose.koinInject
 
 val LocalViewModelFactory = compositionLocalOf<TreeTrackerViewModelFactory> { error { "No active ViewModel factory found!" } }
 val LocalNavHostController = compositionLocalOf<NavHostController> { error { "No NavHostController found!" } }
@@ -31,10 +39,25 @@ val LocalNavHostController = compositionLocalOf<NavHostController> { error { "No
 fun Root(viewModelFactory: TreeTrackerViewModelFactory) {
     val navController = rememberNavController()
 
+    // OrgRepo holds its current org only in memory, so it is lost on process death.
+    // When the OS restores the app into a deep screen the splash screen — and therefore
+    // OrgRepo.init() — is bypassed, and any screen that reads currentOrg() would crash.
+    // Re-hydrate it once per process before rendering the (possibly restored) back stack.
+    val orgRepo = koinInject<OrgRepo>()
+    var isOrgReady by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        orgRepo.ensureInitialized()
+        isOrgReady = true
+    }
+
     CompositionLocalProvider(
         LocalViewModelFactory provides viewModelFactory,
         LocalNavHostController provides navController,
     ) {
-        Host()
+        if (isOrgReady) {
+            Host()
+        } else {
+            Splash()
+        }
     }
 }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/splash/SplashScreenViewModel.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/splash/SplashScreenViewModel.kt
@@ -64,7 +64,10 @@ class SplashScreenViewModel(
     suspend fun bootstrap() {
         deviceConfigUpdater.saveLatestConfig()
 
-        orgRepo.init()
+        // The Root gate hydrates OrgRepo before this screen composes, so this is
+        // normally a no-op; ensureInitialized() (not init()) avoids a redundant
+        // reload and stays correct if the gate is ever bypassed.
+        orgRepo.ensureInitialized()
         orgJsonString?.let { orgRepo.addOrgFromJsonString(it) }
 
         if (checkForInternetUseCase.execute(Unit)) {

--- a/app/src/test/java/org/greenstand/android/TreeTracker/splash/SplashScreenViewModelTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/splash/SplashScreenViewModelTest.kt
@@ -111,7 +111,7 @@ class SplashScreenViewModelTest {
             splashScreenViewModel.bootstrap()
 
             coVerify(exactly = 1) { deviceConfigUpdater.saveLatestConfig() }
-            coVerify(exactly = 1) { orgRepo.init() }
+            coVerify(exactly = 1) { orgRepo.ensureInitialized() }
             coVerify(exactly = 0) { orgRepo.addOrgFromJsonString(orgJsonString ?: "some string") }
             coVerify(exactly = 1) { messagesRepo.syncMessages() }
             coVerify(exactly = 1) { exceptionDataCollector.set(ExceptionDataCollector.POWER_USER_WALLET, user.wallet) }
@@ -131,7 +131,7 @@ class SplashScreenViewModelTest {
             splashScreenViewModel.bootstrap()
 
             coVerify(exactly = 1) { deviceConfigUpdater.saveLatestConfig() }
-            coVerify(exactly = 1) { orgRepo.init() }
+            coVerify(exactly = 1) { orgRepo.ensureInitialized() }
             coVerify(exactly = 0) { orgRepo.addOrgFromJsonString(orgJsonString ?: "some stirng") }
             coVerify(exactly = 0) { messagesRepo.syncMessages() }
             coVerify(exactly = 0) { exceptionDataCollector.set(ExceptionDataCollector.POWER_USER_WALLET, user.wallet) }


### PR DESCRIPTION
Backport of #1299 to `releases/2.2.1`.

## Problem

`OrgRepo` keeps its current org **only in memory** and is populated solely by `orgRepo.init()` in the splash screen's `bootstrap()`. When the OS kills the app in the background and restores it directly into a deep screen (e.g. mid capture-setup flow), the splash screen — and therefore `init()` — is bypassed, leaving `currentOrg` null. The next access crashes when `CaptureSetupNavigationController`'s constructor reads `orgRepo.currentOrg()`, surfaced by Koin as `InstanceCreationException`:

```
java.lang.IllegalStateException: OrgRepo not initialized. Call init() before accessing currentOrg().
    at OrgRepo.currentOrg(OrgRepo.kt)
    at CaptureSetupNavigationController.<init>(CaptureSetupNavigationController.kt)
    at org.koin.core.instance.InstanceFactory.create(...)
    at CaptureSetupScopeManager.getNav(SetupScope.kt)
    at UserSelectScreenKt$UserSelectScreen$1$1$1.invokeSuspend(UserSelectScreen.kt)
```

## Fix

Re-hydrate `OrgRepo` once per process at the composition root (`Root`), gating `Host()` behind a new idempotent `suspend ensureInitialized()`, so every restored destination has a populated org before it can read `currentOrg()`. The splash `bootstrap()` now calls `ensureInitialized()` instead of `init()` so it doesn't redundantly re-initialize on a normal cold start.

## Backport notes

`releases/2.2.1` has diverged from `master` (it predates the snackbar/UiEvent refactor and uses the `orgJsonString` / `addOrgFromJsonString` deeplink path), so the two commits were cherry-picked with manual conflict resolution:
- `Root.kt` — reapplied the gate onto the branch's simpler `Root` (no `SnackbarController`).
- `SplashScreenViewModel.kt` — kept this branch's `orgJsonString?.let { orgRepo.addOrgFromJsonString(it) }` and only swapped `init()` → `ensureInitialized()`.
- `OrgRepo.kt` merged cleanly.

Compiles clean on `releases/2.2.1` (`:app:compileDebugKotlin`). The behavioral fix was verified end-to-end on an emulator on the master version (#1299): without it, process death → restore into UserSelect → forward reproduces the crash; with it, navigation proceeds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)