### PR TITLE
fix: prevent crash when reading malformed JSON from messages DB

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/database/Converters.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/database/Converters.kt
@@ -20,6 +20,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toInstant
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import timber.log.Timber
 
 object Converters {
     val json = Json { ignoreUnknownKeys = true }
@@ -27,7 +28,11 @@ object Converters {
     @TypeConverter
     fun jsonToMap(value: String?): Map<String, String>? {
         if (value == null) return null
-        return json.decodeFromString<Map<String, String>>(value)
+        return runCatching { json.decodeFromString<Map<String, String>>(value) }
+            .getOrElse {
+                Timber.e(it, "Failed to decode map from stored value: %s", value)
+                null
+            }
     }
 
     @TypeConverter
@@ -40,12 +45,23 @@ object Converters {
     fun instantToString(instant: Instant?): String? = instant?.let { it.toString() }
 
     @TypeConverter
-    fun stringToInstance(s: String?): Instant? = s?.toInstant()
+    fun stringToInstance(s: String?): Instant? {
+        if (s == null) return null
+        return runCatching { s.toInstant() }
+            .getOrElse {
+                Timber.e(it, "Failed to parse Instant from stored value: %s", s)
+                null
+            }
+    }
 
     @TypeConverter
     fun stringToArray(value: String?): List<String>? {
         if (value == null) return null
-        return json.decodeFromString<List<String>>(value)
+        return runCatching { json.decodeFromString<List<String>>(value) }
+            .getOrElse {
+                Timber.e(it, "Failed to decode list from stored value: %s", value)
+                null
+            }
     }
 
     @TypeConverter

--- a/app/src/test/java/org/greenstand/android/TreeTracker/database/ConvertersTest.kt
+++ b/app/src/test/java/org/greenstand/android/TreeTracker/database/ConvertersTest.kt
@@ -103,4 +103,30 @@ class ConvertersTest {
 
             assertNull(result)
         }
+
+    @Test
+    fun `WHEN stringToArray receives malformed JSON THEN returns null instead of throwing`() =
+        runTest {
+            // Regression: a malformed/legacy survey_response value used to crash
+            // reads of the entire messages table via getMessagesForWalletFlow.
+            val result = Converters.stringToArray("not a json array")
+
+            assertNull(result)
+        }
+
+    @Test
+    fun `WHEN jsonToMap receives malformed JSON THEN returns null instead of throwing`() =
+        runTest {
+            val result = Converters.jsonToMap("not a json object")
+
+            assertNull(result)
+        }
+
+    @Test
+    fun `WHEN stringToInstance receives malformed value THEN returns null instead of throwing`() =
+        runTest {
+            val result = Converters.stringToInstance("not an instant")
+
+            assertNull(result)
+        }
 }


### PR DESCRIPTION
## Problem

A crash was reported originating from `Converters.stringToArray`, called by `MessagesDAO_Impl.getMessagesForWalletFlow`:

```
kotlinx.serialization.json.internal.JsonDecodingException
  at org.greenstand.android.TreeTracker.database.Converters.stringToArray
  at ...MessagesDAO_Impl.getMessagesForWalletFlow$lambda$0
```

`stringToArray` decodes the `survey_response` column (`List<String>?`) on `MessageEntity` with a strict `json.decodeFromString`. A single row holding a malformed/legacy value (anything that isn't a valid JSON array) throws `JsonDecodingException` inside Room's row mapping for the `Flow`, so the exception propagates out and crashes the app — and keeps crashing on every read of that wallet's messages.

## Fix

Wrap the three **read-side** converters (`stringToArray`, `jsonToMap`, `stringToInstance`) in `runCatching { … }.getOrElse { Timber.e(…); null }`. A bad row now logs and degrades to `null` instead of taking down the whole message list. Write-side converters stay strict.

## Verification

Added regression tests for malformed input on each decoder in `ConvertersTest`.

- **Before** (old code): the new tests fail with the exact exception from the crash — `JsonDecodingException: Expected start of the array '[', but had 'n'`.
- **After**: all 11/11 `ConvertersTest` cases pass.
- **Emulator smoke test**: built/installed the `dev` variant on Pixel_2_API_27, app launches and stays alive with no `FATAL`/`JsonDecodingException` in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)