### PR TITLE
ci: require screenshot + video on PRs (template + status check)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,24 @@ Before submitting your PR, there are a few things you can do to make sure it goe
 - [ ] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
 - [ ] Appropriate docs were updated (if necessary)
 
+## 📸 Proof of change (REQUIRED)
+
+> **Every PR must include a screen recording / video showing the change working.**
+> **UI changes must also include before/after screenshots.**
+> Just drag-and-drop the files into the boxes below — GitHub will upload them.
+> PRs without the required media will be flagged automatically and **cannot be merged**.
+
+### 🎥 Screen recording / video (always required)
+
+<!-- Drag a short screen recording (.mp4 / .mov / .webm) here, or paste a Loom/YouTube link. -->
+
+### 🖼️ Screenshots (required for any UI change)
+
+| Before | After |
+| ------ | ----- |
+|        |       |
+
+- [ ] This change has **no user-visible / UI effect** (refactor, docs, CI, etc.), so screenshots are not applicable.
+  - A maintainer may also apply the `non-ui` label. **A video is still required** even for non-UI changes.
+
 Fixes #<issue_number_goes_here> 🦕

--- a/.github/workflows/require-pr-media.yml
+++ b/.github/workflows/require-pr-media.yml
@@ -1,0 +1,129 @@
+name: Require PR media
+
+# Ensures every PR includes a screen recording / video, and a screenshot for UI
+# changes. Posts a friendly comment tagging the author when something is missing,
+# and fails a status check so the PR cannot be merged until it is fixed.
+#
+# Escape hatch: apply the `non-ui` label (or tick the "no user-visible / UI effect"
+# box in the PR description) to skip the screenshot requirement. A video is still
+# required even for non-UI changes.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+# pull_request_target runs in the base-repo context so we can comment on PRs from
+# forks. We only read the PR body/labels and post a comment — no untrusted code is
+# checked out or executed.
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: require-pr-media-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-media:
+    name: Check for screenshot & video
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = '<!-- require-pr-media -->';
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const author = pr.user.login;
+
+            // --- Detect a screenshot (an embedded image) --------------------
+            const hasScreenshot =
+              /!\[[^\]]*\]\([^)]+\)/.test(body) ||   // ![alt](url) markdown image
+              /<img\b[^>]*>/i.test(body);            // <img ...> html
+
+            // Strip embedded images so their URLs are not mistaken for a video.
+            const withoutImages = body
+              .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+              .replace(/<img\b[^>]*>/gi, ' ');
+
+            // --- Detect a video --------------------------------------------
+            const hasVideo =
+              /\.(mp4|mov|webm|m4v|avi|mkv)\b/i.test(withoutImages) ||       // file extension
+              /<video[\s>]/i.test(withoutImages) ||                          // <video> html
+              // A GitHub-hosted attachment that is NOT an embedded image is treated
+              // as a video (GitHub renders uploaded videos as a bare attachment URL).
+              /https?:\/\/(?:github\.com\/user-attachments\/assets|user-images\.githubusercontent\.com)\/\S+/i.test(withoutImages) ||
+              // Common external video hosts.
+              /https?:\/\/(?:www\.)?(?:youtube\.com|youtu\.be|loom\.com|vimeo\.com|streamable\.com|drive\.google\.com)\/\S+/i.test(withoutImages);
+
+            // --- Is this a non-UI change? ----------------------------------
+            const labels = (pr.labels || []).map(l => l.name.toLowerCase());
+            const nonUiLabel = labels.some(n =>
+              ['non-ui', 'no-ui', 'no-ui-change', 'non-ui-change'].includes(n));
+            const nonUiCheckbox =
+              /- \[x\][^\n]*no user-visible/i.test(body) ||
+              /- \[x\][^\n]*no\b[^\n]*ui\b/i.test(body);
+            const isNonUi = nonUiLabel || nonUiCheckbox;
+
+            // --- Work out what is missing ----------------------------------
+            const missing = [];
+            if (!hasVideo) {
+              missing.push('a **🎥 screen recording / video** demonstrating the change');
+            }
+            if (!isNonUi && !hasScreenshot) {
+              missing.push('a **🖼️ screenshot** of the UI change (or mark the PR as `non-ui` if there is no UI change)');
+            }
+
+            // --- Compose the comment ---------------------------------------
+            let commentBody;
+            if (missing.length === 0) {
+              commentBody = [
+                MARKER,
+                `✅ Thanks @${author} — required media detected. Nothing more needed here!`,
+              ].join('\n');
+            } else {
+              commentBody = [
+                MARKER,
+                `👋 Hi @${author}, thanks for the contribution!`,
+                '',
+                'Before this PR can be reviewed and merged, please add:',
+                '',
+                ...missing.map(m => `- ${m}`),
+                '',
+                'Just drag-and-drop the file(s) into the PR description and GitHub will upload them. ' +
+                'This check re-runs automatically when you edit the description.',
+                '',
+                isNonUi
+                  ? '_This PR is marked as non-UI, so a screenshot is not required — but a video still is._'
+                  : '_If this change has no user-visible effect, tick the "no user-visible / UI effect" box in the description (or ask a maintainer to add the `non-ui` label) to skip the screenshot requirement._',
+              ].join('\n');
+            }
+
+            // --- Upsert the comment (avoid spamming on every edit) ---------
+            const { owner, repo } = context.repo;
+            const issue_number = pr.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => (c.body || '').includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body: commentBody,
+              });
+            } else if (missing.length > 0) {
+              // Only create a brand-new comment when there is something to ask for.
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body: commentBody,
+              });
+            }
+
+            // --- Fail the check if media is missing ------------------------
+            if (missing.length > 0) {
+              core.setFailed(
+                'Missing required PR media: ' +
+                missing.map(m => m.replace(/\*\*/g, '').replace(/[🎥🖼️]/g, '').trim()).join('; '),
+              );
+            } else {
+              core.info('All required PR media present.');
+            }


### PR DESCRIPTION
## Problem

Many contributions (frequently AI-assisted) arrive with **no visual proof** of the change. Maintainers then have to manually request a screenshot or screen recording on nearly every PR, which slows review and is easy to forget. The current PR template has no place to attach media at all.

## Solution

Make proof-of-change **structural and enforced** instead of a manual reminder.

### 1. PR template (`.github/pull_request_template.md`)
- New **"📸 Proof of change (REQUIRED)"** section.
- A **screen recording / video is always required.**
- **Before/after screenshots required for UI changes** (before/after table).
- Escape-hatch checkbox for changes with **no user-visible effect** (skips screenshots, video still required).

### 2. Status-check workflow (`.github/workflows/require-pr-media.yml`)
- Runs on PR `opened` / `edited` / `reopened` / `synchronize` / `labeled` / `unlabeled`.
- Scans the PR description for:
  - a **video** — `.mp4/.mov/.webm/...`, `<video>`, a GitHub-uploaded attachment, or a YouTube/Loom/Vimeo/etc. link (**always required**), and
  - a **screenshot** — markdown image or `<img>` (**required unless the PR is non-UI**).
- When something is missing it **upserts a single friendly comment tagging the author** and **fails the check** so the PR can't be merged. The comment auto-updates (and resolves to ✅) as the description is edited — no spam.

### Non-UI escape hatch
Apply the **`non-ui`** label (maintainer) or tick the template's "no user-visible / UI effect" box (contributor). This **skips the screenshot requirement but still requires a video.**

## Notes / follow-up
- Uses `pull_request_target` so it can comment on **fork PRs**; it only reads the PR body/labels and posts a comment — no untrusted code is checked out.
- Detection logic was unit-tested locally against empty / image-only / video-only / image+video / external-link / non-UI permutations — all behave as intended.
- **To actually block merges**, mark the **"Check for screenshot & video"** check as **required** in branch protection for `master`. Without that it will still post the comment and show ❌, but won't hard-block.
- You may want to create a `non-ui` label if one doesn't already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)