### PR TITLE
chore(firebase): refresh google-services.json; prerelease reuses release app

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -3,10 +3,124 @@
     "project_number": "422699885542",
     "firebase_url": "https://tree-tracker-a7a13.firebaseio.com",
     "project_id": "tree-tracker-a7a13",
-    "storage_bucket": "tree-tracker-a7a13.appspot.com"
+    "storage_bucket": "tree-tracker-a7a13.firebasestorage.app"
   },
   "client": [
-{
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:422699885542:android:e673ea9e40b77f6aa0ec27",
+        "android_client_info": {
+          "package_name": "com.ftt.android.TreeTracker"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:422699885542:android:dc800825e887261ea0ec27",
+        "android_client_info": {
+          "package_name": "org.greenstand.android.TreeTracker"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:422699885542:android:dc800825e887261ea0ec27",
+        "android_client_info": {
+          "package_name": "org.greenstand.android.TreeTracker.prerelease"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:422699885542:android:11ddac217a11a7f4a0ec27",
+        "android_client_info": {
+          "package_name": "org.greenstand.android.TreeTracker.debug"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:422699885542:android:0d0fe64a4522d006a0ec27",
+        "android_client_info": {
+          "package_name": "org.greenstand.android.TreeTracker.dev"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:422699885542:android:695c2cf8b13db668a0ec27",
+        "android_client_info": {
+          "package_name": "org.greenstand.android.TreeTracker.justdiggit"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
       "client_info": {
         "mobilesdk_app_id": "1:422699885542:android:aab16ef8fc4e5968a0ec27",
         "android_client_info": {
@@ -21,10 +135,6 @@
             "package_name": "org.greenstand.android.TreeTracker.test",
             "certificate_hash": "c06a47237965c9690d2f571f4e1ceb09b4efe52b"
           }
-        },
-        {
-          "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-          "client_type": 3
         }
       ],
       "api_key": [
@@ -34,130 +144,7 @@
       ],
       "services": {
         "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-      {
-      "client_info": {
-        "mobilesdk_app_id": "1:422699885542:android:993c29134938ce4d",
-        "android_client_info": {
-          "package_name": "org.greenstand.android.TreeTracker"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:422699885542:android:993c29134938ce4d",
-        "android_client_info": {
-          "package_name": "org.greenstand.android.TreeTracker.dev"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:422699885542:android:993c29134938ce4d",
-        "android_client_info": {
-          "package_name": "org.greenstand.android.TreeTracker.debug"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyC5u6w2W3zKwFRnMHxxPnje34Mc6R3jpno"
-        }
-      ],
-      "services": {
-        "appinvite_service": {
-          "other_platform_oauth_client": [
-            {
-              "client_id": "422699885542-aec38c6t8ji3n81hfq5lhfnjde1hb58s.apps.googleusercontent.com",
-              "client_type": 3
-            }
-          ]
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:301103308242:android:993c29134938ce4d",
-        "android_client_info": {
-          "package_name": "org.greenstand.android.TreeTracker.prerelease"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "301103308242-lrrl3ccujjvdjls8udg4oejqn57324ja.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyDjQOMe8wZ68wgzfkwsA6tq87SEDPvHBN8"
-        }
-      ],
-      "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "appinvite_service": {
-          "status": 1,
           "other_platform_oauth_client": []
-        },
-        "ads_service": {
-          "status": 2
         }
       }
     }


### PR DESCRIPTION
## What

Refreshes the project `app/google-services.json` from a fresh Firebase console download (project `tree-tracker-a7a13`) and makes the `prerelease` build type report into the **production** Firebase app.

## Why

The fresh download:
- Re-adds the `.debug` app (it had been missing from an earlier export).
- Includes two newly registered apps — `com.ftt.android.TreeTracker` and `org.greenstand.android.TreeTracker.justdiggit` — which are not yet referenced by any build type (harmless, just present in the file).
- **Did not include a `.prerelease` app.** The Google Services plugin fails the build if a variant's `package_name` is absent, so the `prerelease` build would break.

Rather than registering a separate `.prerelease` Firebase app, the `.prerelease` client now reuses the **release** app's `mobilesdk_app_id` and API key. So prerelease builds group their Crashlytics/Analytics under the production Firebase app, consistent with prerelease already using production backends (prod API gateway + prod S3).

## Build variant → Firebase app id

| Variant | applicationId suffix | Firebase app id |
|---|---|---|
| release | *(none)* | `…:dc800825e887261ea0ec27` |
| prerelease | `.prerelease` | `…:dc800825e887261ea0ec27` (same as release) |
| debug | `.debug` | `…:11ddac217a11a7f4a0ec27` |
| beta | `.test` | `…:aab16ef8fc4e5968a0ec27` |
| dev | `.dev` | `…:0d0fe64a4522d006a0ec27` |

## Notes / trade-offs

- Prerelease crashes/events will appear under the **production** app in the dashboards (not a separate prerelease bucket) — intended grouping.
- The two extra apps in the file are unused by the current build types.

## Testing

Config-only change. Verified every build-variant package name resolves to a client entry in the JSON. No UI changes — N/A for screenshots/video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)