### PR TITLE
Automate production release signing

### DIFF
--- a/.github/workflows/actions/build-apk/action.yml
+++ b/.github/workflows/actions/build-apk/action.yml
@@ -13,10 +13,27 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Validate production and release signing secrets
+      if: inputs.decode_keystore == 'true'
+      shell: bash
+      run: |
+        missing=()
+        [ -n "${S3_PRODUCTION_IDENTITY_POOL_ID}" ] || missing+=("S3_PRODUCTION_IDENTITY_POOL_ID")
+        [ -n "${PROD_TREETRACKER_CLIENT_ID}" ] || missing+=("PROD_TREETRACKER_CLIENT_ID")
+        [ -n "${PROD_TREETRACKER_CLIENT_SECRET}" ] || missing+=("PROD_TREETRACKER_CLIENT_SECRET")
+        [ -n "${KEYSTORE_FILE}" ] || missing+=("KEYSTORE_FILE")
+        [ -n "${KEYSTORE_PASSWORD}" ] || missing+=("KEYSTORE_PASSWORD")
+        [ -n "${KEY_ALIAS}" ] || missing+=("KEY_ALIAS")
+        [ -n "${KEY_PASSWORD}" ] || missing+=("KEY_PASSWORD")
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "Missing required production release secrets: ${missing[*]}"
+          exit 1
+        fi
+
     - name: Decode keystore (for release builds)
       if: inputs.decode_keystore == 'true'
       shell: bash
-      run: echo "${{ env.KEYSTORE_FILE }}" | base64 -d > keystore.jks
+      run: echo "${KEYSTORE_FILE}" | base64 --decode > keystore.jks
 
     - name: Make gradlew executable
       shell: bash

--- a/.github/workflows/actions/setup-property-file/action.yml
+++ b/.github/workflows/actions/setup-property-file/action.yml
@@ -35,3 +35,9 @@ runs:
         echo "treetracker_client_secret=${TREETRACKER_CLIENT_SECRET}" >> treetracker.keys.properties
         echo "prod_treetracker_client_id=${PROD_TREETRACKER_CLIENT_ID}" >> treetracker.keys.properties
         echo "prod_treetracker_client_secret=${PROD_TREETRACKER_CLIENT_SECRET}" >> treetracker.keys.properties
+        if [ -n "${KEYSTORE_FILE}" ]; then
+          echo "release_store_file=../keystore.jks" >> treetracker.keys.properties
+          echo "release_store_password=${KEYSTORE_PASSWORD}" >> treetracker.keys.properties
+          echo "release_key_alias=${KEY_ALIAS}" >> treetracker.keys.properties
+          echo "release_key_password=${KEY_PASSWORD}" >> treetracker.keys.properties
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ obj/
 #Keys
 treetracker.keys.properties
 secrets.tar
+*.jks
+*.keystore
 
 #Fastlane
 fastlane/report.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,27 @@ def loadExtraProperties(String fileName) {
 loadExtraProperties("treetracker.keys.properties")
 
 android {
+    signingConfigs {
+        release {
+            def requiredProperties = [
+                    'release_store_file',
+                    'release_store_password',
+                    'release_key_alias',
+                    'release_key_password'
+            ]
+            def missingProperties = requiredProperties.findAll {
+                !project.hasProperty(it) || project.property(it).toString().trim().isEmpty()
+            }
+
+            if (missingProperties.isEmpty()) {
+                storeFile file(project.property('release_store_file'))
+                storePassword project.property('release_store_password')
+                keyAlias project.property('release_key_alias')
+                keyPassword project.property('release_key_password')
+            }
+        }
+    }
+
     compileSdk libs.versions.compileSdk.get().toInteger()
     defaultConfig {
         applicationId "org.greenstand.android.TreeTracker"
@@ -70,6 +91,7 @@ android {
     buildTypes {
         release {
             minifyEnabled true
+            signingConfig signingConfigs.release
             resValue "string", "app_name", "Tree Tracker"
             buildConfigField "String", "OBJECT_STORAGE_IDENTITY_POOL_ID", "\"${s3_production_identity_pool_id}\""
             buildConfigField 'String', 'OBJECT_STORAGE_ENDPOINT', '"eu-central-1"'

--- a/docs/getting-started/environment-setup.md
+++ b/docs/getting-started/environment-setup.md
@@ -19,3 +19,22 @@
 5. Run the app from Android Studio or use Gradle commands from [Common Commands](common-commands.md).
 
 See also: [Prerequisites](prerequisites.md), [Build Variants](build-variants.md).
+
+## Production release configuration
+
+Production releases are built by the `Deploy to Google Play Store` GitHub
+Actions workflow. Repository administrators must configure these Actions
+secrets:
+
+- `S3_PRODUCTION_IDENTITY_POOL_ID`
+- `PROD_TREETRACKER_CLIENT_ID`
+- `PROD_TREETRACKER_CLIENT_SECRET`
+- `KEYSTORE_FILE` (the release keystore encoded as base64)
+- `KEYSTORE_PASSWORD`
+- `KEY_ALIAS`
+- `KEY_PASSWORD`
+- `PLAY_STORE_SERVICE_ACCOUNT`
+
+The workflow creates `treetracker.keys.properties` and decodes the keystore
+only for the duration of the build. These generated files must never be
+committed to the repository.


### PR DESCRIPTION
## Summary

- configure Gradle to sign release builds with the production keystore
- generate signing properties from GitHub Actions secrets
- fail release builds clearly when production or signing secrets are missing
- ignore keystore files and document the required repository secrets

## Testing

- `git diff --check`
- Gradle project configuration with JDK 17 and synthetic credentials
- release signing configuration loaded with a disposable test keystore
- full `assembleRelease` reached Android task dependency resolution; local completion is blocked because this machine does not have the Android SDK

## Proof of change

### Screen recording / video

https://github.com/user-attachments/assets/33e99994-7eb8-4842-ac1e-3c25ed3676de

### Screenshots

- [x] This change has **no user-visible / UI effect**, so screenshots are not applicable.

Fixes #1132