### PR TITLE
fix: ensure language is initialized on app startup and applied before navigating to privacy screen

### DIFF
--- a/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguageSelectScreen.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/languagepicker/LanguageSelectScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,7 +35,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.greenstand.android.TreeTracker.models.Language
+import org.greenstand.android.TreeTracker.models.LanguageSwitcher
 import org.greenstand.android.TreeTracker.navigation.SignupFlowRoute
+import org.koin.compose.koinInject
 import org.greenstand.android.TreeTracker.root.LocalNavHostController
 import org.greenstand.android.TreeTracker.root.LocalViewModelFactory
 import org.greenstand.android.TreeTracker.theme.CustomTheme
@@ -53,6 +56,18 @@ fun LanguageSelectScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val navController = LocalNavHostController.current
+    val languageSwitcher = koinInject<LanguageSwitcher>()
+    val languageChangeComplete by languageSwitcher.languageChangeComplete.collectAsState()
+
+    LaunchedEffect(languageChangeComplete) {
+        if (languageChangeComplete) {
+            if (isFromTopBar) {
+                navController.throttledPopBackStack()
+            } else {
+                navController.throttledNavigate(SignupFlowRoute)
+            }
+        }
+    }
 
     LanguageSelect(
         state = state,
@@ -60,11 +75,6 @@ fun LanguageSelectScreen(
             when (action) {
                 is LanguagePickerAction.NavigateNext -> {
                     viewModel.handleAction(LanguagePickerAction.ConfirmLanguage)
-                    if (isFromTopBar) {
-                        navController.throttledPopBackStack()
-                    } else {
-                        navController.throttledNavigate(SignupFlowRoute)
-                    }
                 }
                 else -> viewModel.handleAction(action)
             }

--- a/app/src/main/java/org/greenstand/android/TreeTracker/models/LanguageSwitcher.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/models/LanguageSwitcher.kt
@@ -18,6 +18,8 @@ package org.greenstand.android.TreeTracker.models
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.mapNotNull
 import org.greenstand.android.TreeTracker.preferences.PrefKey
 import org.greenstand.android.TreeTracker.preferences.PrefKeys
@@ -46,6 +48,9 @@ enum class Language(
 class LanguageSwitcher(
     private val prefs: Preferences,
 ) {
+    private val _languageChangeComplete = MutableStateFlow(false)
+    val languageChangeComplete = _languageChangeComplete.asStateFlow()
+
     fun applyCurrentLanguage() {
         val language = Language.fromString(prefs.getString(LANGUAGE_PREF_KEY) ?: "")
         language?.also { setLanguage(it) }
@@ -56,6 +61,7 @@ class LanguageSwitcher(
         AppCompatDelegate.setApplicationLocales(
             LocaleListCompat.forLanguageTags(language.locale.toLanguageTag()),
         )
+        _languageChangeComplete.value = true
     }
 
     fun currentLanguage(): Language? = Language.fromString(prefs.getString(LANGUAGE_PREF_KEY) ?: "")

--- a/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
+++ b/app/src/main/java/org/greenstand/android/TreeTracker/root/Root.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import org.greenstand.android.TreeTracker.models.LanguageSwitcher
 import org.greenstand.android.TreeTracker.models.TreeTrackerViewModelFactory
 import org.greenstand.android.TreeTracker.models.organization.OrgRepo
 import org.greenstand.android.TreeTracker.splash.Splash
@@ -66,9 +67,11 @@ fun Root(viewModelFactory: TreeTrackerViewModelFactory) {
     // OrgRepo.init() — is bypassed, and any screen that reads currentOrg() would crash.
     // Re-hydrate it once per process before rendering the (possibly restored) back stack.
     val orgRepo = koinInject<OrgRepo>()
+    val languageSwitcher = koinInject<LanguageSwitcher>()
     var isOrgReady by remember { mutableStateOf(false) }
     LaunchedEffect(Unit) {
         orgRepo.ensureInitialized()
+        languageSwitcher.applyCurrentLanguage()
         isOrgReady = true
     }
 


### PR DESCRIPTION
… navigation

Issues Fixed:
1. App never reads saved language preference on startup
2. Race condition: app navigates before locale change is applied

Solution:
- Root.kt: Call applyCurrentLanguage() in startup LaunchedEffect
- LanguageSelectScreen.kt: Use LanguageSwitcher.languageChangeComplete StateFlow to wait for language change before navigating

Thank you for opening a Pull Request!

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests are added/updated (if necessary)
- [ ] Ensure the linter passes (`./codeAnalysis` to automatically apply formatting/linting)
- [ ] Appropriate docs were updated (if necessary)

## 📸 Proof of change (REQUIRED)

> **Every PR must include a screen recording / video showing the change working.**
> **UI changes must also include before/after screenshots.**
> Just drag-and-drop the files into the boxes below — GitHub will upload them.
> PRs without the required media will be flagged automatically and **cannot be merged**.

### 🎥 Screen recording / video (always required)

<!-- Drag a short screen recording (.mp4 / .mov / .webm) here, or paste a Loom/YouTube link. -->

### 🖼️ Screenshots (required for any UI change)

| Before | After |
| ------ | ----- |
|        |       |

- [ ] This change has **no user-visible / UI effect** (refactor, docs, CI, etc.), so screenshots are not applicable.
  - A maintainer may also apply the `non-ui` label. **A video is still required** even for non-UI changes.
@
<img width="1080" height="2400" alt="Screenshot_20260713_205751" src="https://github.com/user-attachments/assets/c6eec348-cd3e-4c74-b4ab-2ee5468539aa" />

Fixes #<1270> 🦕
